### PR TITLE
WASM 1.1 control instructions implementation

### DIFF
--- a/include/common/ast/instruction.h
+++ b/include/common/ast/instruction.h
@@ -84,7 +84,7 @@ public:
   Expect<void> loadBinary(FileMgr &Mgr) override;
 
   /// Getter of block type
-  ValType getResultType() const { return BlockType; }
+  BlockType getBlockType() const { return ResType; }
 
   /// Getter of Block Body
   const InstrVec &getBody() const { return Body; }
@@ -92,7 +92,7 @@ public:
 private:
   /// \name Data of block instruction: return type and block body.
   /// @{
-  ValType BlockType;
+  BlockType ResType;
   InstrVec Body;
   /// @}
 }; // namespace AST
@@ -117,7 +117,7 @@ public:
   Expect<void> loadBinary(FileMgr &Mgr) override;
 
   /// Getter of block type
-  ValType getResultType() const { return BlockType; }
+  BlockType getBlockType() const { return ResType; }
 
   /// Getter of if statement.
   const InstrVec &getIfStatement() const { return IfStatement; }
@@ -128,7 +128,7 @@ public:
 private:
   /// \name Data of block instruction: return type and statements.
   /// @{
-  ValType BlockType;
+  BlockType ResType;
   InstrVec IfStatement;
   InstrVec ElseStatement;
   /// @}

--- a/include/common/errcode.h
+++ b/include/common/errcode.h
@@ -46,53 +46,93 @@ enum class ErrCode : uint8_t {
   WrongVMWorkflow = 0x03,   /// Wrong VM's workflow
   FuncNotFound = 0x04,      /// Wasm function not found
   /// Load phase
-  InvalidPath = 0x10,    /// File not found
-  ReadError = 0x11,      /// Error when reading
-  EndOfFile = 0x12,      /// Reach end of file when reading
-  InvalidGrammar = 0x13, /// Parsing error
-  InvalidVersion = 0x14, /// Unsupported version
+  InvalidPath = 0x20,    /// File not found
+  ReadError = 0x21,      /// Error when reading
+  EndOfFile = 0x22,      /// Reach end of file when reading
+  InvalidGrammar = 0x23, /// Parsing error
+  InvalidVersion = 0x24, /// Unsupported version
   /// Validation phase
-  ValidationFailed = 0x20, /// Validation checking failed
+  InvalidOpCode = 0x40,      /// Invalid instruction type
+  InvalidAlignment = 0x41,   /// Alignment > natural
+  TypeCheckFailed = 0x42,    /// Got unexpected type when checking
+  InvalidLabelIdx = 0x43,    /// Branch to unknown label index
+  InvalidLocalIdx = 0x44,    /// Access unknown local index
+  InvalidFuncTypeIdx = 0x45, /// Type index not defined
+  InvalidFuncIdx = 0x46,     /// Function index not defined
+  InvalidTableIdx = 0x47,    /// Table index not defined
+  InvalidMemoryIdx = 0x48,   /// Memory index not defined
+  InvalidGlobalIdx = 0x49,   /// Global index not defined
+  ConstExprRequired = 0x4A,  /// Should be constant expression
+  DupExportName = 0x4B,      /// Export name conflicted
+  ImmutableGlobal = 0x4C,    /// Tried to store to const global value
+  MultiTables = 0x4D,        /// #Tables > 1
+  MultiMemories = 0x4E,      /// #Memories > 1
+  InvalidLimit = 0x4F,       /// Invalid Limit grammar
+  InvalidMemPages = 0x50,    /// Memory pages > 65536
+  InvalidStartFunc = 0x51,   /// Invalid start function signature
   /// Instantiation phase
-  ModuleNameConflict = 0x30,     /// Module name conflicted when importing.
-  IncompatibleImportType = 0x31, /// Import matching failed
-  UnknownImport = 0x32,          /// Unknown import instances
-  DataSegDoesNotFit = 0x33,      /// Init failed when instantiating data segment
-  ElemSegDoesNotFit = 0x34, /// Init failed when instantiating element segment
+  ModuleNameConflict = 0x60,     /// Module name conflicted when importing.
+  IncompatibleImportType = 0x61, /// Import matching failed
+  UnknownImport = 0x62,          /// Unknown import instances
+  DataSegDoesNotFit = 0x63,      /// Init failed when instantiating data segment
+  ElemSegDoesNotFit = 0x64, /// Init failed when instantiating element segment
   /// Execution phase
-  WrongInstanceAddress = 0x40, /// Wrong access of instances addresses
-  WrongInstanceIndex = 0x41,   /// Wrong access of instances indices
-  InstrTypeMismatch = 0x42,    /// Instruction type not match
-  FuncSigMismatch = 0x43,      /// Function signature not match when invoking
-  DivideByZero = 0x44,         /// Divide by zero
-  IntegerOverflow = 0x45,      /// Integer overflow
-  InvalidConvToInt = 0x46,     /// Cannot do convert to integer
-  MemoryOutOfBounds = 0x47,    /// Out of bounds memory access
-  Unreachable = 0x48,          /// Meet an unreachable instruction
-  UninitializedElement = 0x49, /// Uninitialized element in table instance
-  UndefinedElement = 0x4A,     /// Access undefined element in table instances
-  IndirectCallTypeMismatch = 0x4B, /// Func type mismatch in call_indirect
-  ExecutionFailed = 0x4C           /// Host function execution failed
+  WrongInstanceAddress = 0x80, /// Wrong access of instances addresses
+  WrongInstanceIndex = 0x81,   /// Wrong access of instances indices
+  InstrTypeMismatch = 0x82,    /// Instruction type not match
+  FuncSigMismatch = 0x83,      /// Function signature not match when invoking
+  DivideByZero = 0x84,         /// Divide by zero
+  IntegerOverflow = 0x85,      /// Integer overflow
+  InvalidConvToInt = 0x86,     /// Cannot do convert to integer
+  MemoryOutOfBounds = 0x87,    /// Out of bounds memory access
+  Unreachable = 0x88,          /// Meet an unreachable instruction
+  UninitializedElement = 0x89, /// Uninitialized element in table instance
+  UndefinedElement = 0x8A,     /// Access undefined element in table instances
+  IndirectCallTypeMismatch = 0x8B, /// Func type mismatch in call_indirect
+  ExecutionFailed = 0x8C           /// Host function execution failed
 };
 
 /// Error code enumeration string mapping.
 static inline std::unordered_map<ErrCode, std::string> ErrCodeStr = {
+    /// SSVM runtime
     {ErrCode::Success, "success"},
     {ErrCode::Terminated, "terminated"},
     {ErrCode::CostLimitExceeded, "cost limit exceeded"},
     {ErrCode::WrongVMWorkflow, "wrong VM workflow"},
     {ErrCode::FuncNotFound, "wasm function not found"},
+    /// Load phase
     {ErrCode::InvalidPath, "invalid path"},
     {ErrCode::ReadError, "read error"},
     {ErrCode::EndOfFile, "read end of file"},
     {ErrCode::InvalidGrammar, "invalid wasm grammar"},
     {ErrCode::InvalidVersion, "invalid version"},
-    {ErrCode::ValidationFailed, "validation failed"},
+    /// Validation phase
+    {ErrCode::InvalidOpCode, "invalid instruction opcode"},
+    {ErrCode::InvalidAlignment, "alignment must not be larger than natural"},
+    {ErrCode::TypeCheckFailed, "type mismatch"},
+    {ErrCode::InvalidLabelIdx, "unknown label"},
+    {ErrCode::InvalidLocalIdx, "unknown local"},
+    {ErrCode::InvalidFuncTypeIdx, "unknown type"},
+    {ErrCode::InvalidFuncIdx, "unknown function"},
+    {ErrCode::InvalidTableIdx, "unknown table"},
+    {ErrCode::InvalidMemoryIdx, "unknown memory"},
+    {ErrCode::InvalidGlobalIdx, "unknown global"},
+    {ErrCode::ConstExprRequired, "constant expression required"},
+    {ErrCode::DupExportName, "duplicate export name"},
+    {ErrCode::ImmutableGlobal, "global is immutable"},
+    {ErrCode::MultiTables, "multiple tables"},
+    {ErrCode::MultiMemories, "multiple memories"},
+    {ErrCode::InvalidLimit, "size minimum must not be greater than maximum"},
+    {ErrCode::InvalidMemPages,
+     "memory size must be at most 65536 pages (4GiB)"},
+    {ErrCode::InvalidStartFunc, "start function"},
+    /// Instantiation phase
     {ErrCode::ModuleNameConflict, "module name conflict"},
     {ErrCode::IncompatibleImportType, "incompatible import type"},
     {ErrCode::UnknownImport, "unknown import"},
     {ErrCode::DataSegDoesNotFit, "data segment does not fit"},
     {ErrCode::ElemSegDoesNotFit, "elements segment does not fit"},
+    /// Execution phase
     {ErrCode::WrongInstanceAddress, "wrong instance address"},
     {ErrCode::WrongInstanceIndex, "wrong instance index"},
     {ErrCode::InstrTypeMismatch, "instruction type mismatch"},
@@ -108,7 +148,7 @@ static inline std::unordered_map<ErrCode, std::string> ErrCodeStr = {
     {ErrCode::ExecutionFailed, "host function failed"}};
 
 static inline WasmPhase getErrCodePhase(ErrCode Code) {
-  return static_cast<WasmPhase>((static_cast<uint8_t>(Code) & 0xF0) >> 4);
+  return static_cast<WasmPhase>((static_cast<uint8_t>(Code) & 0xF0) >> 5);
 }
 
 static inline std::ostream &operator<<(std::ostream &OS, ErrCode Code) {

--- a/include/common/errinfo.h
+++ b/include/common/errinfo.h
@@ -26,15 +26,19 @@ namespace ErrInfo {
 
 /// Error info type enumeration class.
 enum class InfoType : uint8_t {
-  File,        /// Information about file name which loading from
-  Loading,     /// Information about bytecode offset
-  AST,         /// Information about tracing AST nodes
-  Registering, /// Information about instantiating modules
-  Linking,     /// Information about linking instances
-  Executing,   /// Information about running functions
-  Mismatch,    /// Information about comparison of instances when error
-  Instruction, /// Information about aborted instructions and parameters
-  Boundary     /// Information about forbidden offset accessing
+  File,          /// Information about file name which loading from
+  Loading,       /// Information about bytecode offset
+  AST,           /// Information about tracing AST nodes
+  InstanceBound, /// Information about over boundary of limited #instances
+  ForbidIndex,   /// Information about forbidden accessing of indices
+  Exporting,     /// Information about exporting instances
+  Limit,         /// Information about Limit value
+  Registering,   /// Information about instantiating modules
+  Linking,       /// Information about linking instances
+  Executing,     /// Information about running functions
+  Mismatch,      /// Information about comparison error
+  Instruction,   /// Information about aborted instructions and parameters
+  Boundary       /// Information about forbidden offset accessing
 };
 
 /// Instance addressing type enumeration class.
@@ -46,8 +50,12 @@ enum class PtrType : uint8_t {
 static inline std::unordered_map<PtrType, std::string> PtrTypeStr = {
     {PtrType::Index, "index"}, {PtrType::Address, "address"}};
 
-/// Wasm instance category.
-enum class InstCategory : uint8_t {
+/// Mismatch category.
+enum class MismatchCategory : uint8_t {
+  Alignment,    /// Alignment in memory instructions
+  ValueType,    /// Value type
+  ValueTypes,   /// Value type list
+  Mutation,     /// Const or Var
   ExternalType, /// External typing
   FunctionType, /// Function type
   Table,        /// Table instance
@@ -56,13 +64,37 @@ enum class InstCategory : uint8_t {
   Version       /// Versions
 };
 
-static inline std::unordered_map<InstCategory, std::string> InstCategoryStr = {
-    {InstCategory::ExternalType, "external type"},
-    {InstCategory::FunctionType, "function type"},
-    {InstCategory::Table, "table"},
-    {InstCategory::Memory, "memory"},
-    {InstCategory::Global, "global"},
-    {InstCategory::Version, "version"}};
+static inline std::unordered_map<MismatchCategory, std::string>
+    MismatchCategoryStr = {{MismatchCategory::Alignment, "memory alignment"},
+                           {MismatchCategory::ValueType, "value type"},
+                           {MismatchCategory::ValueTypes, "value types"},
+                           {MismatchCategory::Mutation, "mutation"},
+                           {MismatchCategory::ExternalType, "external type"},
+                           {MismatchCategory::FunctionType, "function type"},
+                           {MismatchCategory::Table, "table"},
+                           {MismatchCategory::Memory, "memory"},
+                           {MismatchCategory::Global, "global"},
+                           {MismatchCategory::Version, "version"}};
+
+/// Wasm index category.
+enum class IndexCategory : uint8_t {
+  Label,
+  Local,
+  FunctionType,
+  Function,
+  Table,
+  Memory,
+  Global
+};
+
+static inline std::unordered_map<IndexCategory, std::string> IndexCategoryStr =
+    {{IndexCategory::Label, "label"},
+     {IndexCategory::Local, "local"},
+     {IndexCategory::FunctionType, "function type"},
+     {IndexCategory::Function, "function"},
+     {IndexCategory::Table, "table"},
+     {IndexCategory::Memory, "memory"},
+     {IndexCategory::Global, "global"}};
 
 /// Information structures.
 struct InfoFile {
@@ -91,6 +123,55 @@ struct InfoAST {
   friend std::ostream &operator<<(std::ostream &OS, const struct InfoAST &Rhs);
 
   ASTNodeAttr NodeAttr;
+};
+
+struct InfoInstanceBound {
+  InfoInstanceBound() = default;
+  InfoInstanceBound(const ExternalType Inst, const uint32_t Num,
+                    const uint32_t Lim) noexcept
+      : Instance(Inst), Number(Num), Limited(Lim) {}
+
+  friend std::ostream &operator<<(std::ostream &OS,
+                                  const struct InfoInstanceBound &Rhs);
+
+  ExternalType Instance;
+  uint32_t Number, Limited;
+};
+
+struct InfoForbidIndex {
+  InfoForbidIndex() = default;
+  InfoForbidIndex(const IndexCategory Cate, const uint32_t Idx,
+                  const uint32_t Bound) noexcept
+      : Category(Cate), Index(Idx), Boundary(Bound) {}
+
+  friend std::ostream &operator<<(std::ostream &OS,
+                                  const struct InfoForbidIndex &Rhs);
+
+  IndexCategory Category;
+  uint32_t Index, Boundary;
+};
+
+struct InfoExporting {
+  InfoExporting() = default;
+  InfoExporting(std::string_view Ext) noexcept : ExtName(Ext) {}
+
+  friend std::ostream &operator<<(std::ostream &OS,
+                                  const struct InfoExporting &Rhs);
+
+  std::string ExtName;
+};
+
+struct InfoLimit {
+  InfoLimit() = default;
+  InfoLimit(const bool HasMax, const uint32_t Min,
+            const uint32_t Max = 0) noexcept
+      : LimHasMax(HasMax), LimMin(Min), LimMax(Max) {}
+
+  friend std::ostream &operator<<(std::ostream &OS,
+                                  const struct InfoLimit &Rhs);
+
+  bool LimHasMax;
+  uint32_t LimMin, LimMax;
 };
 
 struct InfoRegistering {
@@ -132,20 +213,42 @@ struct InfoExecuting {
 
 struct InfoMismatch {
   InfoMismatch() = default;
-  /// Case 1: unexpected external types
+
+  /// Case 1: unexpected alignment
+  InfoMismatch(const uint8_t ExpAlign, const uint32_t GotAlign) noexcept
+      : Category(MismatchCategory::Alignment), ExpAlignment(ExpAlign),
+        GotAlignment(GotAlign) {}
+
+  /// Case 2: unexpected value type
+  InfoMismatch(const ValType ExpVT, const ValType GotVT) noexcept
+      : Category(MismatchCategory::ValueType), ExpValType(ExpVT),
+        GotValType(GotVT) {}
+
+  /// Case 3: unexpected value type list
+  InfoMismatch(const std::vector<ValType> &ExpV,
+               const std::vector<ValType> &GotV) noexcept
+      : Category(MismatchCategory::ValueTypes), ExpParams(ExpV),
+        GotParams(GotV) {}
+
+  /// Case 4: unexpected mutation settings
+  InfoMismatch(const ValMut ExpM, const ValMut GotM) noexcept
+      : Category(MismatchCategory::Mutation), ExpValMut(ExpM), GotValMut(GotM) {
+  }
+
+  /// Case 5: unexpected external types
   InfoMismatch(const ExternalType ExpExt, const ExternalType GotExt) noexcept
-      : Category(InstCategory::ExternalType), ExpExtType(ExpExt),
+      : Category(MismatchCategory::ExternalType), ExpExtType(ExpExt),
         GotExtType(GotExt) {}
 
-  /// Case 2: unexpected function types
+  /// Case 6: unexpected function types
   InfoMismatch(const std::vector<ValType> &ExpP,
                const std::vector<ValType> &ExpR,
                const std::vector<ValType> &GotP,
                const std::vector<ValType> &GotR) noexcept
-      : Category(InstCategory::FunctionType), ExpParams(ExpP), GotParams(GotP),
-        ExpReturns(ExpR), GotReturns(GotR) {}
+      : Category(MismatchCategory::FunctionType), ExpParams(ExpP),
+        GotParams(GotP), ExpReturns(ExpR), GotReturns(GotR) {}
 
-  /// Case 3: unexpected table types
+  /// Case 7: unexpected table types
   InfoMismatch(const ElemType ExpEType, /// Element type
                const bool ExpHasMax, const uint32_t ExpMin,
                const uint32_t ExpMax,   /// Expect Limit
@@ -153,55 +256,64 @@ struct InfoMismatch {
                const bool GotHasMax, const uint32_t GotMin,
                const uint32_t GotMax /// Got limit
                ) noexcept
-      : Category(InstCategory::Table), ExpElemType(ExpEType),
+      : Category(MismatchCategory::Table), ExpElemType(ExpEType),
         GotElemType(GotEType), ExpLimHasMax(ExpHasMax), GotLimHasMax(GotHasMax),
         ExpLimMin(ExpMin), GotLimMin(GotMin), ExpLimMax(ExpMax),
         GotLimMax(GotMax) {}
 
-  /// Case 4: unexpected memory limits
+  /// Case 8: unexpected memory limits
   InfoMismatch(const bool ExpHasMax, const uint32_t ExpMin,
                const uint32_t ExpMax, /// Expect Limit
                const bool GotHasMax, const uint32_t GotMin,
                const uint32_t GotMax /// Got limit
                ) noexcept
-      : Category(InstCategory::Memory), ExpLimHasMax(ExpHasMax),
+      : Category(MismatchCategory::Memory), ExpLimHasMax(ExpHasMax),
         GotLimHasMax(GotHasMax), ExpLimMin(ExpMin), GotLimMin(GotMin),
         ExpLimMax(ExpMax), GotLimMax(GotMax) {}
 
-  /// Case 5: unexpected global types
+  /// Case 9: unexpected global types
   InfoMismatch(const ValType ExpVType, const ValMut ExpVMut,
                const ValType GotVType, const ValMut GotVMut) noexcept
-      : Category(InstCategory::Global), ExpValType(ExpVType),
+      : Category(MismatchCategory::Global), ExpValType(ExpVType),
         GotValType(GotVType), ExpValMut(ExpVMut), GotValMut(GotVMut) {}
 
-  /// Case 6: unexpected version
+  /// Case 10: unexpected version
   InfoMismatch(const uint32_t ExpV, const uint32_t GotV) noexcept
-      : Category(InstCategory::Version), ExpVersion(ExpV), GotVersion(GotV) {}
+      : Category(MismatchCategory::Version), ExpVersion(ExpV),
+        GotVersion(GotV) {}
 
   friend std::ostream &operator<<(std::ostream &OS,
                                   const struct InfoMismatch &Rhs);
 
   /// Mismatched category
-  InstCategory Category;
+  MismatchCategory Category;
 
-  /// Case 1: unexpected external type
+  /// Case 1: unexpected alignment
+  uint8_t ExpAlignment;
+  uint32_t GotAlignment;
+
+  /// Case 5: unexpected external type
   ExternalType ExpExtType, GotExtType;
 
-  /// Case 2: unexpected function type
+  /// Case 6: unexpected function type
+  /// Case 3: unexpected value type list
   std::vector<ValType> ExpParams, GotParams;
   std::vector<ValType> ExpReturns, GotReturns;
 
-  /// Case 3 & 4: unexpected table or memory limit
+  /// Case 7 & 8: unexpected table or memory limit
   ElemType ExpElemType, GotElemType;
   bool ExpLimHasMax, GotLimHasMax;
   uint32_t ExpLimMin, GotLimMin;
   uint32_t ExpLimMax, GotLimMax;
 
-  /// Case 5: unexpected global type
+  /// Case 2: unexpected value type
+  /// Case 9: unexpected global type: value type
   ValType ExpValType, GotValType;
+  /// Case 4: unexpected mutation settings
+  /// Case 9: unexpected global type: value mutation
   ValMut ExpValMut, GotValMut;
 
-  /// Case 6: unexpected version
+  /// Case 10: unexpected version
   uint32_t ExpVersion, GotVersion;
 };
 

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <variant>
 
 namespace SSVM {
 
@@ -32,6 +33,9 @@ static inline std::unordered_map<ValType, std::string> ValTypeStr = {
     {ValType::I64, "i64"},
     {ValType::F32, "f32"},
     {ValType::F64, "f64"}};
+
+/// Block type definition
+using BlockType = std::variant<ValType, uint32_t>;
 
 /// Element types enumeration class.
 enum class ElemType : uint8_t { Func = 0x60, FuncRef = 0x70 };

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -214,7 +214,7 @@ private:
   /// \name Helper Functions for block controls.
   /// @{
   /// Helper function for entering blocks.
-  Expect<void> enterBlock(const uint32_t Arity,
+  Expect<void> enterBlock(const uint32_t Locals, const uint32_t Arity,
                           const AST::BlockControlInstruction *Instr,
                           const AST::InstrVec &Seq);
 
@@ -229,7 +229,8 @@ private:
   Expect<void> leaveFunction();
 
   /// Helper function for branching to label.
-  Expect<void> branchToLabel(const uint32_t Cnt);
+  Expect<void> branchToLabel(Runtime::StoreManager &StoreMgr,
+                             const uint32_t Cnt);
   /// @}
 
   /// \name Helper Functions for getting instances.
@@ -250,12 +251,18 @@ private:
   /// \name Run instructions functions
   /// @{
   /// ======= Control instructions =======
-  Expect<void> runBlockOp(const AST::BlockControlInstruction &Instr);
-  Expect<void> runLoopOp(const AST::BlockControlInstruction &Instr);
-  Expect<void> runIfElseOp(const AST::IfElseControlInstruction &Instr);
-  Expect<void> runBrOp(const AST::BrControlInstruction &Instr);
-  Expect<void> runBrIfOp(const AST::BrControlInstruction &Instr);
-  Expect<void> runBrTableOp(const AST::BrTableControlInstruction &Instr);
+  Expect<void> runBlockOp(Runtime::StoreManager &StoreMgr,
+                          const AST::BlockControlInstruction &Instr);
+  Expect<void> runLoopOp(Runtime::StoreManager &StoreMgr,
+                         const AST::BlockControlInstruction &Instr);
+  Expect<void> runIfElseOp(Runtime::StoreManager &StoreMgr,
+                           const AST::IfElseControlInstruction &Instr);
+  Expect<void> runBrOp(Runtime::StoreManager &StoreMgr,
+                       const AST::BrControlInstruction &Instr);
+  Expect<void> runBrIfOp(Runtime::StoreManager &StoreMgr,
+                         const AST::BrControlInstruction &Instr);
+  Expect<void> runBrTableOp(Runtime::StoreManager &StoreMgr,
+                            const AST::BrTableControlInstruction &Instr);
   Expect<void> runReturnOp();
   Expect<void> runCallOp(Runtime::StoreManager &StoreMgr,
                          const AST::CallControlInstruction &Instr);

--- a/include/validator/formchecker.h
+++ b/include/validator/formchecker.h
@@ -27,8 +27,6 @@ namespace Validator {
 
 enum class VType : uint32_t { Unknown, I32, I64, F32, F64 };
 
-/// TODO: Validator should update due to applying multi-value returns in spec.
-
 class FormChecker {
 public:
   FormChecker() = default;
@@ -41,7 +39,7 @@ public:
 
   /// Adder of contexts
   void addType(const AST::FunctionType &Func);
-  void addFunc(const uint32_t &TypeIdx);
+  void addFunc(const uint32_t TypeIdx, const bool IsImport = false);
   void addTable(const AST::TableType &Tab);
   void addMemory(const AST::MemoryType &Mem);
   void addGlobal(const AST::GlobalType &Glob, const bool IsImport = false);
@@ -54,7 +52,12 @@ public:
   auto &getTables() { return Tables; }
   auto &getMemories() { return Mems; }
   auto &getGlobals() { return Globals; }
+  uint32_t getNumImportFuncs() const { return NumImportFuncs; }
   uint32_t getNumImportGlobals() const { return NumImportGlobals; }
+
+  /// Helper function
+  VType ASTToVType(const ValType &V);
+  ValType VTypeToAST(const VType &V);
 
   struct CtrlFrame {
     CtrlFrame() = default;
@@ -76,10 +79,10 @@ public:
   };
 
 private:
-  /// Checking function
-  Expect<void> checkFunc(const AST::InstrVec &Instrs);
-
   /// Checking expression
+  Expect<void> checkExpr(const AST::InstrVec &Instrs);
+
+  /// Checking instruction list
   Expect<void> checkInstrs(const AST::InstrVec &Instrs);
 
   /// Instruction iteration
@@ -96,9 +99,6 @@ private:
   Expect<void> checkInstr(const AST::UnaryNumericInstruction &Instr);
   Expect<void> checkInstr(const AST::BinaryNumericInstruction &Instr);
   Expect<void> checkInstr(const AST::TruncSatNumericInstruction &Instr);
-
-  /// Helper function
-  VType ASTToVType(const ValType &V);
 
   /// Stack operations
   void pushType(VType);
@@ -119,6 +119,7 @@ private:
   std::vector<ElemType> Tables;
   std::vector<uint32_t> Mems;
   std::vector<std::pair<VType, ValMut>> Globals;
+  uint32_t NumImportFuncs = 0;
   uint32_t NumImportGlobals = 0;
   std::vector<VType> Locals;
   std::vector<VType> Returns;

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -32,8 +32,7 @@ public:
 
 private:
   /// Validate AST::Types
-  Expect<void> validate(const AST::Limit &Lim, const uint32_t K);
-  Expect<void> validate(const AST::FunctionType &Func);
+  Expect<void> validate(const AST::Limit &Lim);
   Expect<void> validate(const AST::TableType &Tab);
   Expect<void> validate(const AST::MemoryType &Mem);
   /// GlobalType is always valid.
@@ -51,15 +50,15 @@ private:
 
   /// Validate AST::Sections
   Expect<void> validate(const AST::ImportSection &ImportSec);
-  Expect<void> validate(const AST::FunctionSection &FuncSec,
-                        const AST::CodeSection &CodeSec);
+  Expect<void> validate(const AST::FunctionSection &FuncSec);
   Expect<void> validate(const AST::TableSection &TabSec);
   Expect<void> validate(const AST::MemorySection &MemSec);
   Expect<void> validate(const AST::GlobalSection &GlobSec);
-  Expect<void> validate(const AST::ExportSection &ExportSec);
-  Expect<void> validate(const AST::StartSection &StartSec);
   Expect<void> validate(const AST::ElementSection &ElemSec);
+  Expect<void> validate(const AST::CodeSection &CodeSec);
   Expect<void> validate(const AST::DataSection &DataSec);
+  Expect<void> validate(const AST::StartSection &StartSec);
+  Expect<void> validate(const AST::ExportSection &ExportSec);
 
   /// Validate const expression
   Expect<void> validateConstExpr(const AST::InstrVec &Instrs,

--- a/lib/ast/module.cpp
+++ b/lib/ast/module.cpp
@@ -186,22 +186,22 @@ Expect<void> Module::loadCompiled(LDMgr &Mgr) {
         if (void *Symbol = Mgr.getRawSymbol(Name.c_str())) {
           ExpDesc->setSymbol(Symbol);
         } else {
-          LOG(ERROR) << ErrCode::ValidationFailed;
+          LOG(ERROR) << ErrCode::InvalidGlobalIdx;
           LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Desc_Export);
           LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Sec_Export);
           LOG(ERROR) << ErrInfo::InfoAST(NodeAttr);
-          return Unexpect(ErrCode::ValidationFailed);
+          return Unexpect(ErrCode::InvalidGlobalIdx);
         }
         break;
       case ExternalType::Table:
       case ExternalType::Memory:
         break;
       default:
-        LOG(ERROR) << ErrCode::ValidationFailed;
+        LOG(ERROR) << ErrCode::InvalidMemoryIdx;
         LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Desc_Export);
         LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Sec_Export);
         LOG(ERROR) << ErrInfo::InfoAST(NodeAttr);
-        return Unexpect(ErrCode::ValidationFailed);
+        return Unexpect(ErrCode::InvalidMemoryIdx);
       }
     }
   }

--- a/lib/interpreter/engine/control.cpp
+++ b/lib/interpreter/engine/control.cpp
@@ -8,69 +8,101 @@ namespace SSVM {
 namespace Interpreter {
 
 Expect<void>
-Interpreter::runBlockOp(const AST::BlockControlInstruction &Instr) {
+Interpreter::runBlockOp(Runtime::StoreManager &StoreMgr,
+                        const AST::BlockControlInstruction &Instr) {
   /// Get result type for arity.
-  const ValType ResultType = Instr.getResultType();
-  uint32_t Arity = (ResultType == ValType::None) ? 0 : 1;
+  uint32_t Locals = 0, Arity = 0;
+  if (std::holds_alternative<ValType>(Instr.getBlockType())) {
+    Arity = (std::get<ValType>(Instr.getBlockType()) == ValType::None) ? 0 : 1;
+  } else {
+    /// Get function type at index x.
+    const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
+    const auto *FuncType =
+        *ModInst->getFuncType(std::get<uint32_t>(Instr.getBlockType()));
+    Locals = FuncType->Params.size();
+    Arity = FuncType->Returns.size();
+  }
 
   /// Create Label{ nothing } and push.
-  return enterBlock(Arity, nullptr, Instr.getBody());
+  return enterBlock(Locals, Arity, nullptr, Instr.getBody());
 }
 
-Expect<void> Interpreter::runLoopOp(const AST::BlockControlInstruction &Instr) {
+Expect<void> Interpreter::runLoopOp(Runtime::StoreManager &StoreMgr,
+                                    const AST::BlockControlInstruction &Instr) {
   /// Get result type for arity.
-  const ValType ResultType = Instr.getResultType();
-  uint32_t Arity = (ResultType == ValType::None) ? 0 : 1;
+  uint32_t Arity = 0;
+  if (std::holds_alternative<uint32_t>(Instr.getBlockType())) {
+    /// Get function type at index x.
+    const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
+    const auto *FuncType =
+        *ModInst->getFuncType(std::get<uint32_t>(Instr.getBlockType()));
+    Arity = FuncType->Params.size();
+  }
 
   /// Create Label{ loop-instruction } and push.
-  return enterBlock(Arity, &Instr, Instr.getBody());
+  return enterBlock(Arity, Arity, &Instr, Instr.getBody());
 }
 
 Expect<void>
-Interpreter::runIfElseOp(const AST::IfElseControlInstruction &Instr) {
-  /// Get condition and result type for arity.
+Interpreter::runIfElseOp(Runtime::StoreManager &StoreMgr,
+                         const AST::IfElseControlInstruction &Instr) {
+  /// Get condition.
   ValVariant Cond = StackMgr.pop();
-  ValType ResultType = Instr.getResultType();
-  uint32_t Arity = (ResultType == ValType::None) ? 0 : 1;
+
+  /// Get result type for arity.
+  uint32_t Locals = 0, Arity = 0;
+  if (std::holds_alternative<ValType>(Instr.getBlockType())) {
+    Arity = (std::get<ValType>(Instr.getBlockType()) == ValType::None) ? 0 : 1;
+  } else {
+    /// Get function type at index x.
+    const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
+    const auto *FuncType =
+        *ModInst->getFuncType(std::get<uint32_t>(Instr.getBlockType()));
+    Locals = FuncType->Params.size();
+    Arity = FuncType->Returns.size();
+  }
 
   /// If non-zero, run if-statement; else, run else-statement.
   if (retrieveValue<uint32_t>(Cond) != 0) {
     const auto &IfStatement = Instr.getIfStatement();
     if (!IfStatement.empty()) {
-      return enterBlock(Arity, nullptr, IfStatement);
+      return enterBlock(Locals, Arity, nullptr, IfStatement);
     }
   } else {
     const auto &ElseStatement = Instr.getElseStatement();
     if (!ElseStatement.empty()) {
-      return enterBlock(Arity, nullptr, ElseStatement);
+      return enterBlock(Locals, Arity, nullptr, ElseStatement);
     }
   }
   return {};
 }
 
-Expect<void> Interpreter::runBrOp(const AST::BrControlInstruction &Instr) {
-  return branchToLabel(Instr.getLabelIndex());
+Expect<void> Interpreter::runBrOp(Runtime::StoreManager &StoreMgr,
+                                  const AST::BrControlInstruction &Instr) {
+  return branchToLabel(StoreMgr, Instr.getLabelIndex());
 }
 
-Expect<void> Interpreter::runBrIfOp(const AST::BrControlInstruction &Instr) {
+Expect<void> Interpreter::runBrIfOp(Runtime::StoreManager &StoreMgr,
+                                    const AST::BrControlInstruction &Instr) {
   ValVariant Cond = StackMgr.pop();
   if (retrieveValue<uint32_t>(Cond) != 0) {
-    return runBrOp(Instr);
+    return runBrOp(StoreMgr, Instr);
   }
   return {};
 }
 
 Expect<void>
-Interpreter::runBrTableOp(const AST::BrTableControlInstruction &Instr) {
+Interpreter::runBrTableOp(Runtime::StoreManager &StoreMgr,
+                          const AST::BrTableControlInstruction &Instr) {
   /// Get value on top of stack.
   uint32_t Value = retrieveValue<uint32_t>(StackMgr.pop());
 
   /// Do branch.
   const auto &LabelTable = Instr.getLabelTable();
   if (Value < LabelTable.size()) {
-    return branchToLabel(LabelTable[Value]);
+    return branchToLabel(StoreMgr, LabelTable[Value]);
   }
-  return branchToLabel(Instr.getLabelIndex());
+  return branchToLabel(StoreMgr, Instr.getLabelIndex());
 }
 
 Expect<void> Interpreter::runReturnOp() { return leaveFunction(); }

--- a/lib/interpreter/instantiate/data.cpp
+++ b/lib/interpreter/instantiate/data.cpp
@@ -18,6 +18,8 @@ Interpreter::resolveExpression(Runtime::StoreManager &StoreMgr,
   for (const auto &DataSeg : DataSec.getContent()) {
     /// Run initialize expression.
     if (auto Res = runExpression(StoreMgr, DataSeg->getInstrs()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+      LOG(ERROR) << ErrInfo::InfoAST(DataSeg->NodeAttr);
       return Unexpect(Res);
     }
 
@@ -36,7 +38,6 @@ Interpreter::resolveExpression(Runtime::StoreManager &StoreMgr,
           Offset, DataSeg->getData().size(),
           MemInst->getDataPageSize() * MemInst->kPageSize - 1);
       LOG(ERROR) << ErrInfo::InfoAST(DataSeg->NodeAttr);
-      LOG(ERROR) << ErrInfo::InfoAST(DataSec.NodeAttr);
       return Unexpect(ErrCode::DataSegDoesNotFit);
     }
     Offsets.push_back(Offset);

--- a/lib/interpreter/instantiate/elem.cpp
+++ b/lib/interpreter/instantiate/elem.cpp
@@ -18,6 +18,8 @@ Interpreter::resolveExpression(Runtime::StoreManager &StoreMgr,
   for (const auto &ElemSeg : ElemSec.getContent()) {
     /// Run initialize expression.
     if (auto Res = runExpression(StoreMgr, ElemSeg->getInstrs()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+      LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
       return Unexpect(Res);
     }
 
@@ -35,7 +37,6 @@ Interpreter::resolveExpression(Runtime::StoreManager &StoreMgr,
       LOG(ERROR) << ErrInfo::InfoBoundary(
           Offset, ElemSeg->getFuncIdxes().size(), TabInst->getMin() - 1);
       LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
-      LOG(ERROR) << ErrInfo::InfoAST(ElemSec.NodeAttr);
       return Unexpect(ErrCode::ElemSegDoesNotFit);
     }
     Offsets.push_back(Offset);

--- a/lib/interpreter/instantiate/global.cpp
+++ b/lib/interpreter/instantiate/global.cpp
@@ -33,6 +33,7 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
 
     /// Run initialize expression.
     if (auto Res = runExpression(StoreMgr, GlobSeg->getInstrs()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
       return Unexpect(Res);
     }
 

--- a/lib/interpreter/instantiate/import.cpp
+++ b/lib/interpreter/instantiate/import.cpp
@@ -105,7 +105,6 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       LOG(ERROR) << ErrCode::UnknownImport;
       LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
       LOG(ERROR) << ErrInfo::InfoAST(ImpDesc->NodeAttr);
-      LOG(ERROR) << ErrInfo::InfoAST(ImportSec.NodeAttr);
       return Unexpect(ErrCode::UnknownImport);
     }
     if (auto Res = getImportAddr(ExtName, ExtType, *TargetModInst)) {
@@ -113,7 +112,6 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     } else {
       LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
       LOG(ERROR) << ErrInfo::InfoAST(ImpDesc->NodeAttr);
-      LOG(ERROR) << ErrInfo::InfoAST(ImportSec.NodeAttr);
       return Unexpect(Res);
     }
 
@@ -134,7 +132,6 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
                                             TargetType.Returns);
         LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
         LOG(ERROR) << ErrInfo::InfoAST(ImpDesc->NodeAttr);
-        LOG(ERROR) << ErrInfo::InfoAST(ImportSec.NodeAttr);
         return Unexpect(ErrCode::IncompatibleImportType);
       }
       /// Set the matched function address to module instance.
@@ -159,7 +156,6 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
             TargetInst->getMax());
         LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
         LOG(ERROR) << ErrInfo::InfoAST(ImpDesc->NodeAttr);
-        LOG(ERROR) << ErrInfo::InfoAST(ImportSec.NodeAttr);
         return Unexpect(ErrCode::IncompatibleImportType);
       }
       /// Set the matched table address to module instance.
@@ -183,7 +179,6 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
             TargetInst->getMax());
         LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
         LOG(ERROR) << ErrInfo::InfoAST(ImpDesc->NodeAttr);
-        LOG(ERROR) << ErrInfo::InfoAST(ImportSec.NodeAttr);
         return Unexpect(ErrCode::IncompatibleImportType);
       }
       /// Set the matched memory address to module instance.
@@ -204,7 +199,6 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
             TargetInst->getValType(), TargetInst->getValMut());
         LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
         LOG(ERROR) << ErrInfo::InfoAST(ImpDesc->NodeAttr);
-        LOG(ERROR) << ErrInfo::InfoAST(ImportSec.NodeAttr);
         return Unexpect(ErrCode::IncompatibleImportType);
       }
       /// Set the matched global address to module instance.

--- a/lib/interpreter/instantiate/module.cpp
+++ b/lib/interpreter/instantiate/module.cpp
@@ -94,8 +94,8 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   /// Initialize the tables and memories
   /// Make a new frame {ModInst, locals:none} and push
   StackMgr.pushFrame(ModInst->Addr, /// Module address
-                     0,             /// Arity
-                     0              /// Coarity
+                     0,             /// Arguments num
+                     0              /// Returns num
   );
   std::vector<uint32_t> ElemOffsets, DataOffsets;
 

--- a/lib/interpreter/instantiate/module.cpp
+++ b/lib/interpreter/instantiate/module.cpp
@@ -49,6 +49,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   const AST::ImportSection *ImportSec = Mod.getImportSection();
   if (ImportSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *ImportSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ImportSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -59,6 +60,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   const AST::CodeSection *CodeSec = Mod.getCodeSection();
   if (FuncSec != nullptr && CodeSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *FuncSec, *CodeSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(FuncSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -68,6 +70,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   const AST::GlobalSection *GlobSec = Mod.getGlobalSection();
   if (GlobSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *GlobSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(GlobSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -77,6 +80,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   const AST::TableSection *TabSec = Mod.getTableSection();
   if (TabSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *TabSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(TabSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -86,6 +90,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   const AST::MemorySection *MemSec = Mod.getMemorySection();
   if (MemSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *MemSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(MemSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -105,6 +110,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     if (auto Res = resolveExpression(StoreMgr, *ModInst, *ElemSec)) {
       ElemOffsets = std::move(*Res);
     } else {
+      LOG(ERROR) << ErrInfo::InfoAST(ElemSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -116,6 +122,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     if (auto Res = resolveExpression(StoreMgr, *ModInst, *DataSec)) {
       DataOffsets = std::move(*Res);
     } else {
+      LOG(ERROR) << ErrInfo::InfoAST(DataSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -128,6 +135,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   if (ElemSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *ElemSec, ElemOffsets);
         !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ElemSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -137,6 +145,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   if (DataSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *DataSec, DataOffsets);
         !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(DataSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
@@ -146,6 +155,7 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   const AST::ExportSection *ExportSec = Mod.getExportSection();
   if (ExportSec != nullptr) {
     if (auto Res = instantiate(StoreMgr, *ModInst, *ExportSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ExportSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }

--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -24,7 +24,17 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate and register import section into FormChecker.
   if (Mod.getImportSection() != nullptr) {
     if (auto Res = validate(*Mod.getImportSection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getImportSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+
+  /// Validate function section and register functions into FormChecker.
+  if (Mod.getFunctionSection() != nullptr) {
+    if (auto Res = validate(*Mod.getFunctionSection()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getFunctionSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -32,7 +42,8 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate table section and register tables into FormChecker.
   if (Mod.getTableSection() != nullptr) {
     if (auto Res = validate(*Mod.getTableSection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getTableSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -40,7 +51,8 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate memory section and register memories into FormChecker.
   if (Mod.getMemorySection() != nullptr) {
     if (auto Res = validate(*Mod.getMemorySection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getMemorySection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -48,21 +60,8 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate global section and register globals into FormChecker.
   if (Mod.getGlobalSection() != nullptr) {
     if (auto Res = validate(*Mod.getGlobalSection()); !Res) {
-      LOG(ERROR) << Res.error();
-      return Unexpect(Res);
-    }
-  }
-
-  /// Validate function section and code section.
-  if ((Mod.getFunctionSection() && !Mod.getCodeSection()) ||
-      (!Mod.getFunctionSection() && Mod.getCodeSection())) {
-    /// Function section and code section should be pairly.
-    LOG(ERROR) << ErrCode::ValidationFailed;
-    return Unexpect(ErrCode::ValidationFailed);
-  } else if (Mod.getFunctionSection() && Mod.getCodeSection()) {
-    if (auto Res = validate(*Mod.getFunctionSection(), *Mod.getCodeSection());
-        !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getGlobalSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -70,7 +69,17 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate element section which initialize tables.
   if (Mod.getElementSection() != nullptr) {
     if (auto Res = validate(*Mod.getElementSection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getElementSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+
+  /// Validate code section and expressions.
+  if (Mod.getCodeSection() != nullptr) {
+    if (auto Res = validate(*Mod.getCodeSection()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getCodeSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -78,7 +87,8 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate data section which initialize memories.
   if (Mod.getDataSection() != nullptr) {
     if (auto Res = validate(*Mod.getDataSection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getDataSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -86,7 +96,8 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate start section.
   if (Mod.getStartSection() != nullptr) {
     if (auto Res = validate(*Mod.getStartSection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getStartSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -94,36 +105,36 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
   /// Validate export section.
   if (Mod.getExportSection() != nullptr) {
     if (auto Res = validate(*Mod.getExportSection()); !Res) {
-      LOG(ERROR) << Res.error();
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.getExportSection()->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);
     }
   }
 
   /// In current version, memory and table must be <= 1.
-  if (Checker.getMemories().size() > 1 || Checker.getTables().size() > 1) {
-    LOG(ERROR) << ErrCode::ValidationFailed;
-    return Unexpect(ErrCode::ValidationFailed);
+  if (Checker.getTables().size() > 1) {
+    LOG(ERROR) << ErrCode::MultiTables;
+    LOG(ERROR) << ErrInfo::InfoInstanceBound(ExternalType::Table,
+                                             Checker.getTables().size(), 1);
+    LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+    return Unexpect(ErrCode::MultiTables);
+  }
+  if (Checker.getMemories().size() > 1) {
+    LOG(ERROR) << ErrCode::MultiMemories;
+    LOG(ERROR) << ErrInfo::InfoInstanceBound(ExternalType::Memory,
+                                             Checker.getMemories().size(), 1);
+    LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+    return Unexpect(ErrCode::MultiMemories);
   }
   return {};
 }
 
 /// Validate Limit type. See "include/validator/validator.h".
-Expect<void> Validator::validate(const AST::Limit &Lim, uint32_t K) {
-  bool Cond1 = Lim.getMin() <= K;
-  bool Cond2 =
-      Lim.hasMax() ? (Lim.getMax() <= K && Lim.getMin() <= Lim.getMax()) : true;
-  if (!Cond1 || !Cond2) {
-    return Unexpect(ErrCode::ValidationFailed);
-  }
-  return {};
-}
-
-/// Validate Function type. See "include/validator/validator.h".
-Expect<void> Validator::validate(const AST::FunctionType &Func) {
-  /// The restriction to at most one result may be removed in future versions of
-  /// WebAssembly.
-  if (Func.getReturnTypes().size() > 1) {
-    return Unexpect(ErrCode::ValidationFailed);
+Expect<void> Validator::validate(const AST::Limit &Lim) {
+  if (Lim.hasMax() && Lim.getMin() > Lim.getMax()) {
+    LOG(ERROR) << ErrCode::InvalidLimit;
+    LOG(ERROR) << ErrInfo::InfoLimit(Lim.hasMax(), Lim.getMin(), Lim.getMax());
+    return Unexpect(ErrCode::InvalidLimit);
   }
   return {};
 }
@@ -131,20 +142,40 @@ Expect<void> Validator::validate(const AST::FunctionType &Func) {
 /// Validate Table type. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::TableType &Tab) {
   /// Validate table limits.
-  return validate(*Tab.getLimit(), LIMIT_TABLETYPE);
+  if (auto Res = validate(*Tab.getLimit()); !Res) {
+    return Unexpect(Res);
+  }
+  return {};
 }
 
 /// Validate Memory type. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::MemoryType &Mem) {
   /// Validate memory limits.
-  return validate(*Mem.getLimit(), LIMIT_MEMORYTYPE);
+  const auto *Lim = Mem.getLimit();
+  if (auto Res = validate(*Lim); !Res) {
+    return Unexpect(Res);
+  }
+  if (Lim->getMin() > LIMIT_MEMORYTYPE ||
+      (Lim->hasMax() && Lim->getMax() > LIMIT_MEMORYTYPE)) {
+    LOG(ERROR) << ErrCode::InvalidMemPages;
+    LOG(ERROR) << ErrInfo::InfoLimit(Lim->hasMax(), Lim->getMin(),
+                                     Lim->getMax());
+    return Unexpect(ErrCode::InvalidMemPages);
+  }
+  return {};
 }
 
 /// Validate Global segment. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::GlobalSegment &GlobSeg) {
   /// Check global initialization is a const expression.
-  return validateConstExpr(GlobSeg.getInstrs(),
-                           std::array{GlobSeg.getGlobalType()->getValueType()});
+  if (auto Res = validateConstExpr(
+          GlobSeg.getInstrs(),
+          std::array{GlobSeg.getGlobalType()->getValueType()});
+      !Res) {
+    LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+    return Unexpect(Res);
+  }
+  return {};
 }
 
 /// Validate Element segment. See "include/validator/validator.h".
@@ -152,18 +183,33 @@ Expect<void> Validator::validate(const AST::ElementSegment &ElemSeg) {
   /// Check table index and element type in context.
   const auto &TableVec = Checker.getTables();
   const auto &FuncVec = Checker.getFunctions();
-  if (ElemSeg.getIdx() >= TableVec.size() ||
-      TableVec[ElemSeg.getIdx()] != ElemType::FuncRef) {
-    return Unexpect(ErrCode::ValidationFailed);
+  if (ElemSeg.getIdx() >= TableVec.size()) {
+    LOG(ERROR) << ErrCode::InvalidTableIdx;
+    LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Table,
+                                           ElemSeg.getIdx(), TableVec.size());
+    return Unexpect(ErrCode::InvalidTableIdx);
+  }
+  if (TableVec[ElemSeg.getIdx()] != ElemType::FuncRef) {
+    LOG(ERROR) << ErrCode::InvalidTableIdx;
+    return Unexpect(ErrCode::InvalidTableIdx);
   }
   /// Check function indices exist in context.
   for (auto &Idx : ElemSeg.getFuncIdxes()) {
     if (Idx >= FuncVec.size()) {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::InvalidFuncIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Function,
+                                             Idx, FuncVec.size());
+      return Unexpect(ErrCode::InvalidFuncIdx);
     }
   }
   /// Check table initialization is const expression.
-  return validateConstExpr(ElemSeg.getInstrs(), std::array{ValType::I32});
+  if (auto Res =
+          validateConstExpr(ElemSeg.getInstrs(), std::array{ValType::I32});
+      !Res) {
+    LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+    return Unexpect(Res);
+  }
+  return {};
 }
 
 /// Validate Code segment. See "include/validator/validator.h".
@@ -182,8 +228,13 @@ Expect<void> Validator::validate(const AST::CodeSegment &CodeSeg,
     }
   }
   /// Validate function body expression.
-  return Checker.validate(CodeSeg.getInstrs(),
-                          Checker.getTypes()[TypeIdx].second);
+  if (auto Res = Checker.validate(CodeSeg.getInstrs(),
+                                  Checker.getTypes()[TypeIdx].second);
+      !Res) {
+    LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+    return Unexpect(Res);
+  }
+  return {};
 }
 
 /// Validate Data segment. See "include/validator/validator.h".
@@ -191,10 +242,19 @@ Expect<void> Validator::validate(const AST::DataSegment &DataSeg) {
   /// Check memory index in context.
   const auto &MemVec = Checker.getMemories();
   if (DataSeg.getIdx() >= MemVec.size()) {
-    return Unexpect(ErrCode::ValidationFailed);
+    LOG(ERROR) << ErrCode::InvalidMemoryIdx;
+    LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Memory,
+                                           DataSeg.getIdx(), MemVec.size());
+    return Unexpect(ErrCode::InvalidMemoryIdx);
   }
   /// Check memory initialization is a const expression.
-  return validateConstExpr(DataSeg.getInstrs(), std::array{ValType::I32});
+  if (auto Res =
+          validateConstExpr(DataSeg.getInstrs(), std::array{ValType::I32});
+      !Res) {
+    LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+    return Unexpect(Res);
+  }
+  return {};
 }
 
 /// Validate Import description. See "include/validator/validator.h".
@@ -204,11 +264,16 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
     if (auto TId = ImpDesc.getExternalContent<uint32_t>()) {
       /// Types must exist in context.
       if (*(*TId) >= Checker.getTypes().size()) {
-        return Unexpect(ErrCode::ValidationFailed);
+        LOG(ERROR) << ErrCode::InvalidFuncTypeIdx;
+        LOG(ERROR) << ErrInfo::InfoForbidIndex(
+            ErrInfo::IndexCategory::FunctionType, *(*TId),
+            Checker.getTypes().size());
+        return Unexpect(ErrCode::InvalidFuncTypeIdx);
       }
-      Checker.addFunc(*(*TId));
+      Checker.addFunc(*(*TId), true);
     } else {
-      return Unexpect(TId);
+      LOG(ERROR) << ErrCode::InvalidFuncIdx;
+      return Unexpect(ErrCode::InvalidFuncIdx);
     }
     break;
   case ExternalType::Table:
@@ -217,10 +282,12 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
       if (auto Res = validate(*(*TabType))) {
         Checker.addTable(*(*TabType));
       } else {
+        LOG(ERROR) << ErrInfo::InfoAST((*TabType)->NodeAttr);
         return Unexpect(Res);
       }
     } else {
-      return Unexpect(TabType);
+      LOG(ERROR) << ErrCode::InvalidTableIdx;
+      return Unexpect(ErrCode::InvalidTableIdx);
     }
     break;
   case ExternalType::Memory:
@@ -229,10 +296,12 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
       if (auto Res = validate(*(*MemType))) {
         Checker.addMemory(*(*MemType));
       } else {
+        LOG(ERROR) << ErrInfo::InfoAST((*MemType)->NodeAttr);
         return Unexpect(Res);
       }
     } else {
-      return Unexpect(MemType);
+      LOG(ERROR) << ErrCode::InvalidMemoryIdx;
+      return Unexpect(ErrCode::InvalidMemoryIdx);
     }
     break;
   case ExternalType::Global:
@@ -240,11 +309,12 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
       /// Global type always is valid.
       Checker.addGlobal(*(*GlobType), true);
     } else {
-      return Unexpect(GlobType);
+      LOG(ERROR) << ErrCode::InvalidGlobalIdx;
+      return Unexpect(ErrCode::InvalidGlobalIdx);
     }
     break;
   default:
-    return Unexpect(ErrCode::ValidationFailed);
+    break;
   }
   return {};
 }
@@ -255,26 +325,38 @@ Expect<void> Validator::validate(const AST::ExportDesc &ExpDesc) {
   switch (ExpDesc.getExternalType()) {
   case ExternalType::Function:
     if (Id >= Checker.getFunctions().size()) {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::InvalidFuncIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Function,
+                                             Id, Checker.getFunctions().size());
+      return Unexpect(ErrCode::InvalidFuncIdx);
     }
     break;
   case ExternalType::Table:
     if (Id >= Checker.getTables().size()) {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::InvalidTableIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Table, Id,
+                                             Checker.getTables().size());
+      return Unexpect(ErrCode::InvalidTableIdx);
     }
     break;
   case ExternalType::Memory:
     if (Id >= Checker.getMemories().size()) {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::InvalidMemoryIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Memory, Id,
+                                             Checker.getMemories().size());
+      return Unexpect(ErrCode::InvalidMemoryIdx);
     }
     break;
   case ExternalType::Global:
     if (Id >= Checker.getGlobals().size()) {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::InvalidGlobalIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Global, Id,
+                                             Checker.getGlobals().size());
+      return Unexpect(ErrCode::InvalidGlobalIdx);
     }
     break;
   default:
-    return Unexpect(ErrCode::ValidationFailed);
+    break;
   }
   return {};
 }
@@ -283,50 +365,39 @@ Expect<void> Validator::validate(const AST::ExportDesc &ExpDesc) {
 Expect<void> Validator::validate(const AST::ImportSection &ImportSec) {
   for (auto &ImportDesc : ImportSec.getContent()) {
     if (auto Res = validate(*ImportDesc.get()); !Res) {
-      return Unexpect(ErrCode::ValidationFailed);
-    }
-  }
-  return {};
-}
-
-/// Validate Function section. See "include/validator/validator.h".
-Expect<void> Validator::validate(const AST::FunctionSection &FuncSec,
-                                 const AST::CodeSection &CodeSec) {
-  if (FuncSec.getContent().size() != CodeSec.getContent().size()) {
-    /// Function section length != code section length, failed.
-    return Unexpect(ErrCode::ValidationFailed);
-  }
-
-  const auto &FuncVec = FuncSec.getContent();
-  const auto &CodeVec = CodeSec.getContent();
-  const auto &TypeVec = Checker.getTypes();
-
-  /// Check if type id of function is valid in context.
-  for (size_t Id = 0; Id < FuncVec.size(); ++Id) {
-    uint32_t TId = FuncVec[Id];
-    if (TId >= TypeVec.size()) {
-      return Unexpect(ErrCode::ValidationFailed);
-    }
-    Checker.addFunc(TId);
-  }
-
-  /// Validate function body.
-  for (size_t Id = 0; Id < FuncVec.size(); ++Id) {
-    uint32_t TId = FuncVec[Id];
-    if (auto Res = validate(*CodeVec[Id].get(), TId); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ImportDesc->NodeAttr);
       return Unexpect(Res);
     }
   }
   return {};
 }
 
+/// Validate Function section. See "include/validator/validator.h".
+Expect<void> Validator::validate(const AST::FunctionSection &FuncSec) {
+  const auto &FuncVec = FuncSec.getContent();
+  const auto &TypeVec = Checker.getTypes();
+
+  /// Check if type id of function is valid in context.
+  for (auto &TId : FuncVec) {
+    if (TId >= TypeVec.size()) {
+      LOG(ERROR) << ErrCode::InvalidFuncTypeIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(
+          ErrInfo::IndexCategory::FunctionType, TId, TypeVec.size());
+      return Unexpect(ErrCode::InvalidFuncTypeIdx);
+    }
+    Checker.addFunc(TId);
+  }
+  return {};
+}
+
 /// Validate Table section. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::TableSection &TabSec) {
-  for (auto &Tab : TabSec.getContent()) {
-    if (auto Res = validate(*Tab.get())) {
-      Checker.addTable(*Tab.get());
+  for (auto &TabSeg : TabSec.getContent()) {
+    if (auto Res = validate(*TabSeg.get())) {
+      Checker.addTable(*TabSeg.get());
     } else {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrInfo::InfoAST(TabSeg->NodeAttr);
+      return Unexpect(Res);
     }
   }
   return {};
@@ -334,11 +405,12 @@ Expect<void> Validator::validate(const AST::TableSection &TabSec) {
 
 /// Validate Memory section. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::MemorySection &MemSec) {
-  for (auto &Mem : MemSec.getContent()) {
-    if (auto Res = validate(*Mem.get())) {
-      Checker.addMemory(*Mem.get());
+  for (auto &MemSeg : MemSec.getContent()) {
+    if (auto Res = validate(*MemSeg.get())) {
+      Checker.addMemory(*MemSeg.get());
     } else {
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrInfo::InfoAST(MemSeg->NodeAttr);
+      return Unexpect(Res);
     }
   }
   return {};
@@ -346,12 +418,85 @@ Expect<void> Validator::validate(const AST::MemorySection &MemSec) {
 
 /// Validate Global section. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::GlobalSection &GlobSec) {
-  for (auto &Val : GlobSec.getContent()) {
-    if (auto Res = validate(*Val.get())) {
-      Checker.addGlobal(*Val.get()->getGlobalType());
+  for (auto &GlobSeg : GlobSec.getContent()) {
+    if (auto Res = validate(*GlobSeg.get())) {
+      Checker.addGlobal(*GlobSeg.get()->getGlobalType());
     } else {
+      LOG(ERROR) << ErrInfo::InfoAST(GlobSeg->NodeAttr);
       return Unexpect(Res);
     }
+  }
+  return {};
+}
+
+/// Validate Element section. See "include/validator/validator.h".
+Expect<void> Validator::validate(const AST::ElementSection &ElemSec) {
+  for (auto &ElemSeg : ElemSec.getContent()) {
+    if (auto Res = validate(*ElemSeg.get()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+  return {};
+}
+
+/// Validate Code section. See "include/validator/validator.h".
+Expect<void> Validator::validate(const AST::CodeSection &CodeSec) {
+  const auto &CodeVec = CodeSec.getContent();
+  const auto &FuncVec = Checker.getFunctions();
+
+  /// Validate function body.
+  for (size_t Id = 0; Id < CodeVec.size(); ++Id) {
+    /// Added functions contains imported functions.
+    uint32_t TId = Id + Checker.getNumImportFuncs();
+    if (TId >= FuncVec.size()) {
+      LOG(ERROR) << ErrCode::InvalidFuncIdx;
+      LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Function,
+                                             TId, FuncVec.size());
+      return Unexpect(ErrCode::InvalidFuncIdx);
+    }
+    if (auto Res = validate(*CodeVec[Id].get(), FuncVec[TId]); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(CodeVec[Id]->NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+  return {};
+}
+
+/// Validate Data section. See "include/validator/validator.h".
+Expect<void> Validator::validate(const AST::DataSection &DataSec) {
+  for (auto &Data : DataSec.getContent()) {
+    if (auto Res = validate(*Data.get()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(Data->NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+  return {};
+}
+
+/// Validate Start section. See "include/validator/validator.h".
+Expect<void> Validator::validate(const AST::StartSection &StartSec) {
+  auto FId = StartSec.getContent();
+  if (FId >= Checker.getFunctions().size()) {
+    LOG(ERROR) << ErrCode::InvalidFuncIdx;
+    LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Function,
+                                           FId, Checker.getFunctions().size());
+    return Unexpect(ErrCode::InvalidFuncIdx);
+  }
+  auto TId = Checker.getFunctions()[FId];
+  auto &Type = Checker.getTypes()[TId];
+  if (Type.first.size() != 0 || Type.second.size() != 0) {
+    /// Start function signature should be {}->{}
+    std::vector<ValType> Params, Returns;
+    for (auto &V : Type.first) {
+      Params.push_back(Checker.VTypeToAST(V));
+    }
+    for (auto &V : Type.second) {
+      Returns.push_back(Checker.VTypeToAST(V));
+    }
+    LOG(ERROR) << ErrCode::InvalidStartFunc;
+    LOG(ERROR) << ErrInfo::InfoMismatch({}, {}, Params, Returns);
+    return Unexpect(ErrCode::InvalidStartFunc);
   }
   return {};
 }
@@ -363,43 +508,12 @@ Expect<void> Validator::validate(const AST::ExportSection &ExportSec) {
     auto Result = ExportNames.emplace(ExportDesc->getExternalName());
     if (!Result.second) {
       /// Duplicated export name.
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::DupExportName;
+      LOG(ERROR) << ErrInfo::InfoAST(ExportDesc->NodeAttr);
+      return Unexpect(ErrCode::DupExportName);
     }
     if (auto Res = validate(*ExportDesc.get()); !Res) {
-      return Unexpect(Res);
-    }
-  }
-  return {};
-}
-
-/// Validate Start section. See "include/validator/validator.h".
-Expect<void> Validator::validate(const AST::StartSection &StartSec) {
-  auto FId = StartSec.getContent();
-  if (FId >= Checker.getFunctions().size()) {
-    return Unexpect(ErrCode::ValidationFailed);
-  }
-  auto TId = Checker.getFunctions()[FId];
-  auto &Type = Checker.getTypes()[TId];
-  if (Type.first.size() != 0 || Type.second.size() != 0) {
-    return Unexpect(ErrCode::ValidationFailed);
-  }
-  return {};
-}
-
-/// Validate Element section. See "include/validator/validator.h".
-Expect<void> Validator::validate(const AST::ElementSection &ElemSec) {
-  for (auto &Elem : ElemSec.getContent()) {
-    if (auto Res = validate(*Elem.get()); !Res) {
-      return Unexpect(Res);
-    }
-  }
-  return {};
-}
-
-/// Validate Data section. See "include/validator/validator.h".
-Expect<void> Validator::validate(const AST::DataSection &DataSec) {
-  for (auto &Data : DataSec.getContent()) {
-    if (auto Res = validate(*Data.get()); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ExportDesc->NodeAttr);
       return Unexpect(Res);
     }
   }
@@ -419,7 +533,13 @@ Expect<void> Validator::validateConstExpr(const AST::InstrVec &Instrs,
       if (RestrictGlobal) {
         auto GlobInstr = static_cast<AST::VariableInstruction *>(Instr.get());
         if (GlobInstr->getVariableIndex() >= Checker.getNumImportGlobals()) {
-          return Unexpect(ErrCode::ValidationFailed);
+          LOG(ERROR) << ErrCode::InvalidGlobalIdx;
+          LOG(ERROR) << ErrInfo::InfoForbidIndex(ErrInfo::IndexCategory::Global,
+                                                 GlobInstr->getVariableIndex(),
+                                                 Checker.getNumImportGlobals());
+          LOG(ERROR) << ErrInfo::InfoInstruction(Instr->getOpCode(),
+                                                 Instr->getOffset());
+          return Unexpect(ErrCode::InvalidGlobalIdx);
         }
       }
     case OpCode::I32__const:
@@ -428,7 +548,10 @@ Expect<void> Validator::validateConstExpr(const AST::InstrVec &Instrs,
     case OpCode::F64__const:
       break;
     default:
-      return Unexpect(ErrCode::ValidationFailed);
+      LOG(ERROR) << ErrCode::ConstExprRequired;
+      LOG(ERROR) << ErrInfo::InfoInstruction(Instr->getOpCode(),
+                                             Instr->getOffset());
+      return Unexpect(ErrCode::ConstExprRequired);
     }
   }
   /// Validate expression with result types.

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   ssvm_unit_test
   GIT_REPOSITORY https://github.com/second-state/ssvm-unittest.git
-  GIT_TAG origin/master
+  GIT_TAG wasm-1.1
 )
 
 FetchContent_GetProperties(ssvm_unit_test)


### PR DESCRIPTION
1. Define `blocktype` in control instructions.
2. Update loading in control instructions.
3. Update validator algorithm.
4. Implement multi-value returns in related instructions.
5. Implement multi-value returns in AOT.
6. Turn on `assert_invalid` in core tests.
7. Apply error logging in validator.