### PR TITLE
[AOT] Use mprotect for memory boundary checking

### DIFF
--- a/include/common/ast/type.h
+++ b/include/common/ast/type.h
@@ -85,6 +85,12 @@ public:
   /// The node type should be ASTNodeAttr::Type_Function.
   const ASTNodeAttr NodeAttr = ASTNodeAttr::Type_Function;
 
+  friend bool operator==(const FunctionType &LHS,
+                         const FunctionType &RHS) noexcept {
+    return LHS.ParamTypes == RHS.ParamTypes &&
+           LHS.ReturnTypes == RHS.ReturnTypes;
+  }
+
 private:
   /// \name Data of FunctionType node.
   /// @{

--- a/include/runtime/instance/function.h
+++ b/include/runtime/instance/function.h
@@ -25,7 +25,7 @@ namespace Instance {
 
 class FunctionInstance {
 public:
-  using CompiledFunction = void (*)(void *, const ValVariant *, ValVariant *);
+  using CompiledFunction = void (*)(const ValVariant *Args, ValVariant *Rets);
 
   FunctionInstance() = delete;
   /// Constructor for native function.

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "aot/compiler.h"
+#include "runtime/instance/memory.h"
 #include "support/filesystem.h"
 #include "support/log.h"
 #include <lld/Common/Driver.h>
@@ -13,7 +14,6 @@
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Target/TargetMachine.h>
-#include <llvm/Transforms/IPO/AlwaysInliner.h>
 
 #if LLVM_VERSION_MAJOR >= 10
 #include <llvm/IR/IntrinsicsAArch64.h>
@@ -52,7 +52,10 @@ class FunctionCompiler;
 template <typename... Ts> struct overloaded : Ts... {
   using Ts::operator()...;
 };
-template <typename... Ts> overloaded(Ts...)->overloaded<Ts...>;
+template <typename... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+/// force checking div/rem on zero
+static inline constexpr bool ForceDivCheck = false;
 
 } // namespace
 
@@ -77,79 +80,55 @@ struct SSVM::AOT::Compiler::CompileContext {
       std::tuple<unsigned int, llvm::Function *, SSVM::AST::CodeSegment *>>
       Functions;
   std::vector<llvm::GlobalVariable *> Globals;
-  std::vector<llvm::Function *> Ctors;
-  llvm::GlobalVariable *Trap;
   llvm::GlobalVariable *Call;
   llvm::GlobalVariable *MemGrow;
-  llvm::GlobalVariable *MemSize;
   llvm::GlobalVariable *Mem;
+  llvm::GlobalVariable *TrapCode;
   llvm::GlobalVariable *InstrCount;
+  llvm::Function *Trap;
   llvm::MDNode *Likely;
+  uint32_t MemMin = 1, MemMax = 65536;
   CompileContext(llvm::Module &M)
       : Context(M.getContext()), Module(M),
-        Trap(new llvm::GlobalVariable(
-            Module,
-            llvm::FunctionType::get(llvm::Type::getVoidTy(Context),
-                                    {llvm::Type::getInt8PtrTy(Context),
-                                     llvm::Type::getInt32Ty(Context)},
-                                    false)
-                ->getPointerTo(),
-            false, llvm::GlobalVariable::InternalLinkage, nullptr, "trap")),
         Call(new llvm::GlobalVariable(
             Module,
             llvm::FunctionType::get(llvm::Type::getVoidTy(Context),
-                                    {llvm::Type::getInt8PtrTy(Context),
-                                     llvm::Type::getInt32Ty(Context),
+                                    {llvm::Type::getInt32Ty(Context),
                                      llvm::Type::getInt8PtrTy(Context),
                                      llvm::Type::getInt8PtrTy(Context)},
                                     false)
                 ->getPointerTo(),
-            false, llvm::GlobalVariable::InternalLinkage, nullptr, "call")),
+            true, llvm::GlobalVariable::ExternalLinkage, nullptr, "call")),
         MemGrow(new llvm::GlobalVariable(
             Module,
             llvm::FunctionType::get(llvm::Type::getInt32Ty(Context),
-                                    {llvm::Type::getInt8PtrTy(Context),
-                                     llvm::Type::getInt32Ty(Context)},
-                                    false)
+                                    {llvm::Type::getInt32Ty(Context)}, false)
                 ->getPointerTo(),
-            false, llvm::GlobalVariable::InternalLinkage, nullptr, "memgrow")),
-        MemSize(new llvm::GlobalVariable(
-            Module,
-            llvm::FunctionType::get(llvm::Type::getInt32Ty(Context),
-                                    {llvm::Type::getInt8PtrTy(Context)}, false)
-                ->getPointerTo(),
-            false, llvm::GlobalVariable::InternalLinkage, nullptr, "memsize")),
+            true, llvm::GlobalVariable::ExternalLinkage, nullptr, "memgrow")),
         Mem(new llvm::GlobalVariable(Module, llvm::Type::getInt8PtrTy(Context),
-                                     false, llvm::GlobalValue::ExternalLinkage,
+                                     true, llvm::GlobalValue::ExternalLinkage,
                                      nullptr, "mem")),
+        TrapCode(new llvm::GlobalVariable(
+            Module, llvm::Type::getInt32PtrTy(Context), false,
+            llvm::GlobalValue::ExternalLinkage, nullptr, "code")),
         InstrCount(new llvm::GlobalVariable(
             Module, llvm::Type::getInt64Ty(Context), false,
-            llvm::GlobalValue::ExternalLinkage,
-            llvm::ConstantInt::get(llvm::Type::getInt64Ty(Context), 0),
-            "instr")),
+            llvm::GlobalValue::ExternalLinkage, nullptr, "instr")),
+        Trap(llvm::Function::Create(
+            llvm::FunctionType::get(llvm::Type::getVoidTy(Context),
+                                    {llvm::Type::getInt32Ty(Context)}, false),
+            llvm::Function::InternalLinkage, "trap", Module)),
         Likely(llvm::MDTuple::getDistinct(
             Context, {llvm::MDString::get(Context, "branch_weights"),
                       llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
                           Context, llvm::APInt(32, 2000))),
                       llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
                           Context, llvm::APInt(32, 0)))})) {
-    Trap->setInitializer(
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(
-            Trap->getType()->getPointerElementType())));
-    Call->setInitializer(
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(
-            Call->getType()->getPointerElementType())));
-    MemGrow->setInitializer(
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(
-            MemGrow->getType()->getPointerElementType())));
-    MemSize->setInitializer(
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(
-            MemSize->getType()->getPointerElementType())));
-    Mem->setInitializer(
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(
-            Mem->getType()->getPointerElementType())));
-
-    Trap->addAttribute(llvm::Attribute::NoReturn);
+    Trap->addFnAttr(llvm::Attribute::NoReturn);
+    TrapCode->setInitializer(
+        llvm::ConstantPointerNull::get(llvm::Type::getInt32PtrTy(Context)));
+    InstrCount->setInitializer(
+        llvm::ConstantInt::get(InstrCount->getValueType(), 0));
 
     new llvm::GlobalVariable(
         Module, llvm::Type::getInt32Ty(Context), true,
@@ -177,25 +156,15 @@ struct SSVM::AOT::Compiler::CompileContext {
         SubtargetFeatures.AddFeature(Feature.first(), Feature.second);
       }
     }
-  }
-  void callTrap(llvm::IRBuilder<> &Builder, llvm::Value *Ctx,
-                llvm::Value *Status) {
-    auto *TrapFunc = Builder.CreateLoad(Trap);
-    Builder.CreateCall(TrapFunc, {Ctx, Status});
-  }
-  void callCall(llvm::IRBuilder<> &Builder, llvm::Value *Ctx,
-                llvm::Value *FuncIdx, llvm::Value *Args, llvm::Value *Rets) {
-    auto *CallFunc = Builder.CreateLoad(Call);
-    Builder.CreateCall(CallFunc, {Ctx, FuncIdx, Args, Rets});
-  }
-  llvm::Value *callMemGrow(llvm::IRBuilder<> &Builder, llvm::Value *Ctx,
-                           llvm::Value *NewSize) {
-    auto *MemGrowFunc = Builder.CreateLoad(MemGrow);
-    return Builder.CreateCall(MemGrowFunc, {Ctx, NewSize});
-  }
-  llvm::Value *callMemSize(llvm::IRBuilder<> &Builder, llvm::Value *Ctx) {
-    auto *MemSizeFunc = Builder.CreateLoad(MemSize);
-    return Builder.CreateCall(MemSizeFunc, {Ctx});
+
+    {
+      /// create trap
+      llvm::IRBuilder<> Builder(
+          llvm::BasicBlock::Create(Context, "entry", Trap));
+      Builder.CreateStore(Trap->arg_begin(), Builder.CreateLoad(TrapCode));
+      Builder.CreateIntrinsic(llvm::Intrinsic::trap, {}, {});
+      Builder.CreateUnreachable();
+    }
   }
 };
 
@@ -237,13 +206,7 @@ toLLVMTypeVector(llvm::LLVMContext &Context, Span<const ValType> ValTypes) {
 
 static std::vector<llvm::Type *> toLLVMArgsType(llvm::LLVMContext &Context,
                                                 Span<const ValType> ValTypes) {
-  std::vector<llvm::Type *> Result;
-  Result.reserve(ValTypes.size() + 1);
-  Result.push_back(llvm::Type::getInt8PtrTy(Context));
-  for (const auto &Type : ValTypes) {
-    Result.push_back(toLLVMType(Context, Type));
-  }
-  return Result;
+  return toLLVMTypeVector(Context, ValTypes);
 }
 
 static llvm::Type *toLLVMRetsType(llvm::LLVMContext &Context,
@@ -296,8 +259,13 @@ public:
       Builder.setIsFPConstrained(true);
       Builder.setDefaultConstrainedRounding(RoundingMode::rmToNearest);
       Builder.setDefaultConstrainedExcept(ExceptionBehavior::ebIgnore);
-      Ctx = F->arg_begin();
-      for (llvm::Argument *Arg = Ctx + 1; Arg != F->arg_end(); ++Arg) {
+
+      if (CalculateInstrCount) {
+        LocalInstrCount = Builder.CreateAlloca(Builder.getInt64Ty());
+        Builder.CreateStore(Builder.getInt64(0), LocalInstrCount);
+      }
+
+      for (llvm::Argument *Arg = F->arg_begin(); Arg != F->arg_end(); ++Arg) {
         llvm::Value *ArgPtr = Builder.CreateAlloca(Arg->getType());
         Builder.CreateStore(Arg, ArgPtr);
         Local.push_back(ArgPtr);
@@ -307,15 +275,6 @@ public:
         llvm::Value *ArgPtr = Builder.CreateAlloca(toLLVMType(VMContext, Type));
         Builder.CreateStore(toLLVMConstantZero(VMContext, Type), ArgPtr);
         Local.push_back(ArgPtr);
-      }
-
-      auto *MemPtr = Builder.CreateLoad(Context.Mem);
-      LocalMemPtr = Builder.CreateAlloca(MemPtr->getType());
-      Builder.CreateStore(MemPtr, LocalMemPtr);
-
-      if (CalculateInstrCount) {
-        LocalInstrCount = Builder.CreateAlloca(Builder.getInt64Ty());
-        Builder.CreateStore(Builder.getInt64(0), LocalInstrCount);
       }
     }
   }
@@ -330,9 +289,18 @@ public:
     }
   }
 
+  llvm::BasicBlock *getTrapBB(ErrCode Error) {
+    if (auto Iter = TrapBB.find(Error); Iter != TrapBB.end()) {
+      return Iter->second;
+    }
+    auto *BB = llvm::BasicBlock::Create(VMContext, "trap", F);
+    TrapBB.emplace(Error, BB);
+    return BB;
+  }
+
   Expect<void> compile(const AST::CodeSegment &Code,
                        Span<const ValType> Returns) {
-    llvm::BasicBlock *RetBB = llvm::BasicBlock::Create(VMContext, "ret", F);
+    auto *RetBB = llvm::BasicBlock::Create(VMContext, "ret", F);
     ControlStack.emplace_back(Stack.size(), RetBB, true,
                               std::vector(Returns.begin(), Returns.end()), 0);
 
@@ -342,6 +310,13 @@ public:
 
     buildPHI(Returns, leaveBlock(RetBB));
     compileReturn();
+
+    for (auto &[Error, BB] : TrapBB) {
+      Builder.SetInsertPoint(BB);
+      updateInstrCount();
+      Builder.CreateCall(Context.Trap, {Builder.getInt32(uint32_t(Error))});
+      Builder.CreateUnreachable();
+    }
 
     return {};
   }
@@ -387,10 +362,7 @@ public:
   Expect<void> compile(const AST::ControlInstruction &Instr) {
     switch (Instr.getOpCode()) {
     case OpCode::Unreachable: {
-      updateInstrCount();
-      Context.callTrap(Builder, Ctx,
-                       Builder.getInt32(uint32_t(ErrCode::Unreachable)));
-      Builder.CreateUnreachable();
+      Builder.CreateBr(getTrapBB(ErrCode::Unreachable));
       setUnreachable();
       break;
     }
@@ -416,7 +388,8 @@ public:
       enterBlock(EndBlock, true, Instr.getBlockType());
       Builder.SetInsertPoint(Block);
       compile(Instr.getBody());
-      buildPHI(resolveBlockType(Instr.getBlockType()), leaveBlock(EndBlock));
+      buildPHI(resolveBlockType(Instr.getBlockType()).second,
+               leaveBlock(EndBlock));
       break;
     }
     case OpCode::Loop: {
@@ -427,7 +400,8 @@ public:
       enterBlock(Loop, false, Instr.getBlockType());
       Builder.SetInsertPoint(Loop);
       compile(Instr.getBody());
-      buildPHI(resolveBlockType(Instr.getBlockType()), leaveBlock(EndLoop));
+      buildPHI(resolveBlockType(Instr.getBlockType()).second,
+               leaveBlock(EndLoop));
       break;
     }
     default:
@@ -438,18 +412,33 @@ public:
   Expect<void> compile(const AST::IfElseControlInstruction &Instr) {
     switch (Instr.getOpCode()) {
     case OpCode::If: {
-      llvm::Value *Cond = Builder.CreateICmpNE(stackPop(), Builder.getInt32(0));
+      auto *Cond = Builder.CreateICmpNE(stackPop(), Builder.getInt32(0));
 
       auto *Then = llvm::BasicBlock::Create(VMContext, "then", F);
       auto *Else = llvm::BasicBlock::Create(VMContext, "else", F);
       auto *EndIf = llvm::BasicBlock::Create(VMContext, "if.end", F);
+
+      auto BlockType = resolveBlockType(Instr.getBlockType());
+      const auto Arity = BlockType.first.size();
+      std::vector<llvm::Value *> Args(Arity);
+      for (size_t I = 0; I < Arity; ++I) {
+        const size_t J = Arity - 1 - I;
+        Args[J] = stackPop();
+      }
+
       Builder.CreateCondBr(Cond, Then, Else);
 
+      for (auto *Value : Args) {
+        stackPush(Value);
+      }
       enterBlock(EndIf, true, Instr.getBlockType());
       Builder.SetInsertPoint(Then);
       compile(Instr.getIfStatement());
       auto IfResult = leaveBlock(EndIf);
 
+      for (auto *Value : Args) {
+        stackPush(Value);
+      }
       enterBlock(EndIf, true, Instr.getBlockType());
       Builder.SetInsertPoint(Else);
       compile(Instr.getElseStatement());
@@ -458,7 +447,7 @@ public:
       IfResult.reserve(IfResult.size() + ElseResult.size());
       IfResult.insert(IfResult.end(), ElseResult.begin(), ElseResult.end());
 
-      buildPHI(resolveBlockType(Instr.getBlockType()), IfResult);
+      buildPHI(resolveBlockType(Instr.getBlockType()).second, IfResult);
 
       break;
     }
@@ -468,7 +457,7 @@ public:
     return {};
   }
   Expect<void> compile(const AST::BrControlInstruction &Instr) {
-    const unsigned int Label = Instr.getLabelIndex();
+    const auto Label = Instr.getLabelIndex();
     switch (Instr.getOpCode()) {
     case OpCode::Br: {
       if (!setLableJumpPHI(Label)) {
@@ -495,7 +484,7 @@ public:
     return {};
   }
   Expect<void> compile(const AST::BrTableControlInstruction &Instr) {
-    auto LabelTable = Instr.getLabelTable();
+    const auto LabelTable = Instr.getLabelTable();
     switch (Instr.getOpCode()) {
     case OpCode::Br_table: {
       llvm::Value *Value = stackPop();
@@ -551,7 +540,7 @@ public:
   }
   Expect<void> compile(const AST::VariableInstruction &Instr) {
     /// Get variable index.
-    const unsigned int Index = Instr.getVariableIndex();
+    const auto Index = Instr.getVariableIndex();
 
     /// Check OpCode and run the specific instruction.
     switch (Instr.getOpCode()) {
@@ -651,12 +640,16 @@ public:
       return compileStoreOp(Instr.getMemoryOffset(), Instr.getMemoryAlign(),
                             Builder.getInt32Ty(), true);
     case OpCode::Memory__size:
-      stackPush(Context.callMemSize(Builder, Ctx));
+      stackPush(Builder.CreateCall(Builder.CreateLoad(Context.MemGrow),
+                                   {Builder.getInt32(0)}));
       break;
-    case OpCode::Memory__grow:
-      stackPush(Context.callMemGrow(Builder, Ctx, stackPop()));
-      Builder.CreateStore(Builder.CreateLoad(Context.Mem), LocalMemPtr);
+    case OpCode::Memory__grow: {
+      auto *Diff = stackPop();
+      auto *Result =
+          Builder.CreateCall(Builder.CreateLoad(Context.MemGrow), {Diff});
+      stackPush(Result);
       break;
+    }
     default:
       __builtin_unreachable();
     }
@@ -671,12 +664,14 @@ public:
       stackPush(Builder.getInt64(std::get<uint64_t>(Instr.getConstValue())));
       break;
     case OpCode::F32__const:
-      stackPush(llvm::ConstantFP::get(Builder.getFloatTy(),
-                                      std::get<float>(Instr.getConstValue())));
+      stackPush(llvm::ConstantFP::get(
+          Builder.getFloatTy(),
+          llvm::APFloat(std::get<float>(Instr.getConstValue()))));
       break;
     case OpCode::F64__const:
-      stackPush(llvm::ConstantFP::get(Builder.getDoubleTy(),
-                                      std::get<double>(Instr.getConstValue())));
+      stackPush(llvm::ConstantFP::get(
+          Builder.getDoubleTy(),
+          llvm::APFloat(std::get<double>(Instr.getConstValue()))));
       break;
     default:
       __builtin_unreachable();
@@ -786,12 +781,26 @@ public:
       stackPush(Builder.CreateTrunc(stackPop(), Builder.getInt32Ty()));
       break;
     case OpCode::I32__trunc_f32_s:
+      compileSignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(-0x1p+31f)),
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+31f)),
+          Builder.getInt32Ty());
+      break;
     case OpCode::I32__trunc_f64_s:
-      stackPush(Builder.CreateFPToSI(stackPop(), Builder.getInt32Ty()));
+      compileSignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(-0x1p+31)),
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+31)),
+          Builder.getInt32Ty());
       break;
     case OpCode::I32__trunc_f32_u:
+      compileUnsignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+32f)),
+          Builder.getInt32Ty());
+      break;
     case OpCode::I32__trunc_f64_u:
-      stackPush(Builder.CreateFPToUI(stackPop(), Builder.getInt32Ty()));
+      compileUnsignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+32)),
+          Builder.getInt32Ty());
       break;
     case OpCode::I64__extend_i32_s:
       stackPush(Builder.CreateSExt(stackPop(), Builder.getInt64Ty()));
@@ -800,12 +809,26 @@ public:
       stackPush(Builder.CreateZExt(stackPop(), Builder.getInt64Ty()));
       break;
     case OpCode::I64__trunc_f32_s:
+      compileSignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(-0x1p+63f)),
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+63f)),
+          Builder.getInt64Ty());
+      break;
     case OpCode::I64__trunc_f64_s:
-      stackPush(Builder.CreateFPToSI(stackPop(), Builder.getInt64Ty()));
+      compileSignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(-0x1p+63)),
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+63)),
+          Builder.getInt64Ty());
       break;
     case OpCode::I64__trunc_f32_u:
+      compileUnsignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+64f)),
+          Builder.getInt64Ty());
+      break;
     case OpCode::I64__trunc_f64_u:
-      stackPush(Builder.CreateFPToUI(stackPop(), Builder.getInt64Ty()));
+      compileUnsignedTrunc(
+          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+64)),
+          Builder.getInt64Ty());
       break;
     case OpCode::F32__convert_i32_s:
     case OpCode::F32__convert_i64_s:
@@ -1016,52 +1039,98 @@ public:
       break;
     case OpCode::I32__div_s:
     case OpCode::I64__div_s:
+      if constexpr (ForceDivCheck) {
+        const bool Is32 = Instr.getOpCode() == OpCode::I32__div_s;
+        llvm::ConstantInt *IntZero =
+            Is32 ? Builder.getInt32(0) : Builder.getInt64(0);
+        llvm::ConstantInt *IntMinusOne = Is32 ? Builder.getInt32(int32_t(-1))
+                                              : Builder.getInt64(int64_t(-1));
+        llvm::ConstantInt *IntMin =
+            Is32 ? Builder.getInt32(std::numeric_limits<int32_t>::min())
+                 : Builder.getInt64(std::numeric_limits<int64_t>::min());
+
+        auto *NoZeroBB = llvm::BasicBlock::Create(VMContext, "div.nozero", F);
+        auto *OkBB = llvm::BasicBlock::Create(VMContext, "div.ok", F);
+        Builder.CreateCondBr(Builder.CreateICmpNE(RHS, IntZero), NoZeroBB,
+                             getTrapBB(ErrCode::DivideByZero), Context.Likely);
+
+        Builder.SetInsertPoint(NoZeroBB);
+        auto *NotOverflow =
+            Builder.CreateOr(Builder.CreateICmpNE(LHS, IntMin),
+                             Builder.CreateICmpNE(RHS, IntMinusOne));
+        Builder.CreateCondBr(NotOverflow, OkBB,
+                             getTrapBB(ErrCode::IntegerOverflow),
+                             Context.Likely);
+
+        Builder.SetInsertPoint(OkBB);
+      }
       stackPush(Builder.CreateSDiv(LHS, RHS));
       break;
     case OpCode::I32__div_u:
     case OpCode::I64__div_u:
+      if constexpr (ForceDivCheck) {
+        const bool Is32 = Instr.getOpCode() == OpCode::I32__div_u;
+        llvm::ConstantInt *IntZero =
+            Is32 ? Builder.getInt32(0) : Builder.getInt64(0);
+        auto *OkBB = llvm::BasicBlock::Create(VMContext, "div.ok", F);
+        Builder.CreateCondBr(Builder.CreateICmpNE(RHS, IntZero), OkBB,
+                             getTrapBB(ErrCode::DivideByZero), Context.Likely);
+        Builder.SetInsertPoint(OkBB);
+      }
       stackPush(Builder.CreateUDiv(LHS, RHS));
       break;
     case OpCode::I32__rem_s:
     case OpCode::I64__rem_s: {
       // handle INT32_MIN % -1
-      llvm::ConstantInt *IntZero = Instr.getOpCode() == OpCode::I32__rem_s
-                                       ? Builder.getInt32(0)
-                                       : Builder.getInt64(0);
-      llvm::ConstantInt *IntMinusOne = Instr.getOpCode() == OpCode::I32__rem_s
-                                           ? Builder.getInt32(int32_t(-1))
-                                           : Builder.getInt64(int64_t(-1));
+      const bool Is32 = Instr.getOpCode() == OpCode::I32__rem_s;
+      llvm::ConstantInt *IntMinusOne =
+          Is32 ? Builder.getInt32(int32_t(-1)) : Builder.getInt64(int64_t(-1));
       llvm::ConstantInt *IntMin =
-          Instr.getOpCode() == OpCode::I32__rem_s
-              ? Builder.getInt32(std::numeric_limits<int32_t>::min())
-              : Builder.getInt64(std::numeric_limits<int64_t>::min());
+          Is32 ? Builder.getInt32(std::numeric_limits<int32_t>::min())
+               : Builder.getInt64(std::numeric_limits<int64_t>::min());
+      llvm::ConstantInt *IntZero =
+          Is32 ? Builder.getInt32(0) : Builder.getInt64(0);
 
-      llvm::BasicBlock *CurrentBB = Builder.GetInsertBlock();
-      llvm::BasicBlock *NoOverflowBB =
+      auto *NoOverflowBB =
           llvm::BasicBlock::Create(VMContext, "no.overflow", F);
-      llvm::BasicBlock *EndBB =
-          llvm::BasicBlock::Create(VMContext, "end.overflow", F);
+      auto *EndBB = llvm::BasicBlock::Create(VMContext, "end.overflow", F);
 
-      llvm::Value *NotOverflow =
+      if constexpr (ForceDivCheck) {
+        auto *OkBB = llvm::BasicBlock::Create(VMContext, "rem.ok", F);
+        Builder.CreateCondBr(Builder.CreateICmpNE(RHS, IntZero), OkBB,
+                             getTrapBB(ErrCode::DivideByZero), Context.Likely);
+        Builder.SetInsertPoint(OkBB);
+      }
+
+      auto *CurrBB = Builder.GetInsertBlock();
+      auto *NotOverflow =
           Builder.CreateOr(Builder.CreateICmpNE(LHS, IntMin),
                            Builder.CreateICmpNE(RHS, IntMinusOne));
-
       Builder.CreateCondBr(NotOverflow, NoOverflowBB, EndBB, Context.Likely);
 
       Builder.SetInsertPoint(NoOverflowBB);
-      llvm::Value *Ret1 = Builder.CreateSRem(LHS, RHS);
+      auto *Ret1 = Builder.CreateSRem(LHS, RHS);
       Builder.CreateBr(EndBB);
 
       Builder.SetInsertPoint(EndBB);
-      llvm::PHINode *Ret = Builder.CreatePHI(Ret1->getType(), 2);
+      auto *Ret = Builder.CreatePHI(Ret1->getType(), 2);
       Ret->addIncoming(Ret1, NoOverflowBB);
-      Ret->addIncoming(IntZero, CurrentBB);
+      Ret->addIncoming(IntZero, CurrBB);
 
       stackPush(Ret);
       break;
     }
     case OpCode::I32__rem_u:
     case OpCode::I64__rem_u:
+      if constexpr (ForceDivCheck) {
+        llvm::ConstantInt *IntZero = Instr.getOpCode() == OpCode::I32__rem_u
+                                         ? Builder.getInt32(0)
+                                         : Builder.getInt64(0);
+        auto *OkBB = llvm::BasicBlock::Create(VMContext, "rem.ok", F);
+        Builder.CreateCondBr(Builder.CreateICmpNE(RHS, IntZero), OkBB,
+                             getTrapBB(ErrCode::DivideByZero), Context.Likely);
+        Builder.SetInsertPoint(OkBB);
+      }
       stackPush(Builder.CreateURem(LHS, RHS));
       break;
     case OpCode::I32__and:
@@ -1123,58 +1192,60 @@ public:
       break;
     case OpCode::F32__min:
     case OpCode::F64__min: {
-      llvm::Type *FpTy = Instr.getOpCode() == OpCode::F32__min
-                             ? Builder.getFloatTy()
-                             : Builder.getDoubleTy();
-      llvm::Type *IntTy = Instr.getOpCode() == OpCode::F32__min
-                              ? Builder.getInt32Ty()
-                              : Builder.getInt64Ty();
+      auto *FpTy = Instr.getOpCode() == OpCode::F32__min
+                       ? Builder.getFloatTy()
+                       : Builder.getDoubleTy();
+      auto *IntTy = Instr.getOpCode() == OpCode::F32__min
+                        ? Builder.getInt32Ty()
+                        : Builder.getInt64Ty();
 
-      llvm::Value *UEQ = Builder.CreateFCmpUEQ(LHS, RHS);
-      llvm::Value *UNO = Builder.CreateFCmpUNO(LHS, RHS);
+      auto *UEQ = Builder.CreateFCmpUEQ(LHS, RHS);
+      auto *UNO = Builder.CreateFCmpUNO(LHS, RHS);
 
-      llvm::Value *LHSInt = Builder.CreateBitCast(LHS, IntTy);
-      llvm::Value *RHSInt = Builder.CreateBitCast(RHS, IntTy);
-      llvm::Value *OrInt = Builder.CreateOr(LHSInt, RHSInt);
-      llvm::Value *OrFp = Builder.CreateBitCast(OrInt, FpTy);
+      auto *LHSInt = Builder.CreateBitCast(LHS, IntTy);
+      auto *RHSInt = Builder.CreateBitCast(RHS, IntTy);
+      auto *OrInt = Builder.CreateOr(LHSInt, RHSInt);
+      auto *OrFp = Builder.CreateBitCast(OrInt, FpTy);
 
-      llvm::Value *AddFp = Builder.CreateFAdd(LHS, RHS);
+      auto *AddFp = Builder.CreateFAdd(LHS, RHS);
 
-      llvm::CallInst *MinFp =
+      auto *MinFp =
           Builder.CreateBinaryIntrinsic(llvm::Intrinsic::minnum, LHS, RHS);
       MinFp->setHasNoNaNs(true);
 
-      llvm::Value *Ret = Builder.CreateSelect(
+      auto *Ret = Builder.CreateSelect(
           UEQ, Builder.CreateSelect(UNO, AddFp, OrFp), MinFp);
       stackPush(Ret);
-    } break;
+      break;
+    }
     case OpCode::F32__max:
     case OpCode::F64__max: {
-      llvm::Type *FpTy = Instr.getOpCode() == OpCode::F32__max
-                             ? Builder.getFloatTy()
-                             : Builder.getDoubleTy();
-      llvm::Type *IntTy = Instr.getOpCode() == OpCode::F32__max
-                              ? Builder.getInt32Ty()
-                              : Builder.getInt64Ty();
+      auto *FpTy = Instr.getOpCode() == OpCode::F32__max
+                       ? Builder.getFloatTy()
+                       : Builder.getDoubleTy();
+      auto *IntTy = Instr.getOpCode() == OpCode::F32__max
+                        ? Builder.getInt32Ty()
+                        : Builder.getInt64Ty();
 
-      llvm::Value *UEQ = Builder.CreateFCmpUEQ(LHS, RHS);
-      llvm::Value *UNO = Builder.CreateFCmpUNO(LHS, RHS);
+      auto *UEQ = Builder.CreateFCmpUEQ(LHS, RHS);
+      auto *UNO = Builder.CreateFCmpUNO(LHS, RHS);
 
-      llvm::Value *LHSInt = Builder.CreateBitCast(LHS, IntTy);
-      llvm::Value *RHSInt = Builder.CreateBitCast(RHS, IntTy);
-      llvm::Value *AndInt = Builder.CreateAnd(LHSInt, RHSInt);
-      llvm::Value *AndFp = Builder.CreateBitCast(AndInt, FpTy);
+      auto *LHSInt = Builder.CreateBitCast(LHS, IntTy);
+      auto *RHSInt = Builder.CreateBitCast(RHS, IntTy);
+      auto *AndInt = Builder.CreateAnd(LHSInt, RHSInt);
+      auto *AndFp = Builder.CreateBitCast(AndInt, FpTy);
 
-      llvm::Value *AddFp = Builder.CreateFAdd(LHS, RHS);
+      auto *AddFp = Builder.CreateFAdd(LHS, RHS);
 
-      llvm::CallInst *MaxFp =
+      auto *MaxFp =
           Builder.CreateBinaryIntrinsic(llvm::Intrinsic::maxnum, LHS, RHS);
       MaxFp->setHasNoNaNs(true);
 
-      llvm::Value *Ret = Builder.CreateSelect(
+      auto *Ret = Builder.CreateSelect(
           UEQ, Builder.CreateSelect(UNO, AddFp, AndFp), MaxFp);
       stackPush(Ret);
-    } break;
+      break;
+    }
     case OpCode::F32__copysign:
     case OpCode::F64__copysign:
       stackPush(
@@ -1185,19 +1256,36 @@ public:
     }
     return {};
   }
+  void compileSignedTrunc(llvm::ConstantFP *MinFp, llvm::ConstantFP *MaxFp,
+                          llvm::Type *Type) {
+    auto *NormBB = llvm::BasicBlock::Create(VMContext, "strunc.norm", F);
+    auto *NotMinBB = llvm::BasicBlock::Create(VMContext, "strunc.notmin", F);
+    auto *NotMaxBB = llvm::BasicBlock::Create(VMContext, "strunc.notmax", F);
+    auto *Value = stackPop();
+
+    Builder.CreateCondBr(Builder.CreateFCmpORD(Value, Value), NormBB,
+                         getTrapBB(ErrCode::InvalidConvToInt), Context.Likely);
+
+    Builder.SetInsertPoint(NormBB);
+    Builder.CreateCondBr(Builder.CreateFCmpUGE(Value, MinFp), NotMinBB,
+                         getTrapBB(ErrCode::IntegerOverflow), Context.Likely);
+
+    Builder.SetInsertPoint(NotMinBB);
+    Builder.CreateCondBr(Builder.CreateFCmpULT(Value, MaxFp), NotMaxBB,
+                         getTrapBB(ErrCode::IntegerOverflow), Context.Likely);
+
+    Builder.SetInsertPoint(NotMaxBB);
+    stackPush(Builder.CreateFPToSI(Value, Type));
+  }
   void compileSignedTruncSat(llvm::ConstantFP *MinFp, llvm::ConstantFP *MaxFp,
                              llvm::ConstantInt *MinInt,
                              llvm::ConstantInt *MaxInt) {
-    llvm::BasicBlock *CurrBB = Builder.GetInsertBlock();
-    llvm::BasicBlock *NormBB =
-        llvm::BasicBlock::Create(VMContext, "sats.norm", F);
-    llvm::BasicBlock *NotMinBB =
-        llvm::BasicBlock::Create(VMContext, "sats.notmin", F);
-    llvm::BasicBlock *NotMaxBB =
-        llvm::BasicBlock::Create(VMContext, "sats.notmax", F);
-    llvm::BasicBlock *EndBB =
-        llvm::BasicBlock::Create(VMContext, "sats.end", F);
-    llvm::Value *Value = stackPop();
+    auto *CurrBB = Builder.GetInsertBlock();
+    auto *NormBB = llvm::BasicBlock::Create(VMContext, "ssat.norm", F);
+    auto *NotMinBB = llvm::BasicBlock::Create(VMContext, "ssat.notmin", F);
+    auto *NotMaxBB = llvm::BasicBlock::Create(VMContext, "ssat.notmax", F);
+    auto *EndBB = llvm::BasicBlock::Create(VMContext, "ssat.end", F);
+    auto *Value = stackPop();
 
     Builder.CreateCondBr(Builder.CreateFCmpORD(Value, Value), NormBB, EndBB,
                          Context.Likely);
@@ -1211,12 +1299,12 @@ public:
                          Context.Likely);
 
     Builder.SetInsertPoint(NotMaxBB);
-    llvm::Type *Ty = MaxInt->getType();
-    llvm::Value *IntValue = Builder.CreateFPToSI(Value, Ty);
+    auto *Ty = MaxInt->getType();
+    auto *IntValue = Builder.CreateFPToSI(Value, Ty);
     Builder.CreateBr(EndBB);
 
     Builder.SetInsertPoint(EndBB);
-    llvm::PHINode *PHIRet = Builder.CreatePHI(Ty, 4);
+    auto *PHIRet = Builder.CreatePHI(Ty, 4);
     PHIRet->addIncoming(llvm::ConstantInt::get(Ty, 0), CurrBB);
     PHIRet->addIncoming(MinInt, NormBB);
     PHIRet->addIncoming(MaxInt, NotMinBB);
@@ -1224,16 +1312,35 @@ public:
 
     stackPush(PHIRet);
   }
+  void compileUnsignedTrunc(llvm::ConstantFP *MaxFp, llvm::Type *Type) {
+    auto *NormBB = llvm::BasicBlock::Create(VMContext, "utrunc.norm", F);
+    auto *NotMinBB = llvm::BasicBlock::Create(VMContext, "utrunc.notmin", F);
+    auto *NotMaxBB = llvm::BasicBlock::Create(VMContext, "utrunc.notmax", F);
+    auto *Value = stackPop();
+
+    Builder.CreateCondBr(Builder.CreateFCmpORD(Value, Value), NormBB,
+                         getTrapBB(ErrCode::InvalidConvToInt), Context.Likely);
+
+    Builder.SetInsertPoint(NormBB);
+    Builder.CreateCondBr(
+        Builder.CreateFCmpOGT(Value,
+                              llvm::ConstantFP::get(Value->getType(), -1.0)),
+        NotMinBB, getTrapBB(ErrCode::IntegerOverflow), Context.Likely);
+
+    Builder.SetInsertPoint(NotMinBB);
+    Builder.CreateCondBr(Builder.CreateFCmpOLT(Value, MaxFp), NotMaxBB,
+                         getTrapBB(ErrCode::IntegerOverflow), Context.Likely);
+
+    Builder.SetInsertPoint(NotMaxBB);
+    stackPush(Builder.CreateFPToUI(Value, Type));
+  }
   void compileUnsignedTruncSat(llvm::ConstantFP *MaxFp,
                                llvm::ConstantInt *MaxInt) {
-    llvm::BasicBlock *CurrBB = Builder.GetInsertBlock();
-    llvm::BasicBlock *NormBB =
-        llvm::BasicBlock::Create(VMContext, "sats.norm", F);
-    llvm::BasicBlock *NotMaxBB =
-        llvm::BasicBlock::Create(VMContext, "sats.notmax", F);
-    llvm::BasicBlock *EndBB =
-        llvm::BasicBlock::Create(VMContext, "sats.end", F);
-    llvm::Value *Value = stackPop();
+    auto *CurrBB = Builder.GetInsertBlock();
+    auto *NormBB = llvm::BasicBlock::Create(VMContext, "usat.norm", F);
+    auto *NotMaxBB = llvm::BasicBlock::Create(VMContext, "usat.notmax", F);
+    auto *EndBB = llvm::BasicBlock::Create(VMContext, "usat.end", F);
+    auto *Value = stackPop();
 
     Builder.CreateCondBr(
         Builder.CreateFCmpOGT(Value,
@@ -1245,12 +1352,12 @@ public:
                          Context.Likely);
 
     Builder.SetInsertPoint(NotMaxBB);
-    llvm::Type *Ty = MaxInt->getType();
-    llvm::Value *IntValue = Builder.CreateFPToSI(Value, Ty);
+    auto *Ty = MaxInt->getType();
+    auto *IntValue = Builder.CreateFPToUI(Value, Ty);
     Builder.CreateBr(EndBB);
 
     Builder.SetInsertPoint(EndBB);
-    llvm::PHINode *PHIRet = Builder.CreatePHI(Ty, 3);
+    auto *PHIRet = Builder.CreatePHI(Ty, 3);
     PHIRet->addIncoming(llvm::ConstantInt::get(Ty, 0), CurrBB);
     PHIRet->addIncoming(MaxInt, NormBB);
     PHIRet->addIncoming(IntValue, NotMaxBB);
@@ -1264,10 +1371,10 @@ public:
     if (Ty->isVoidTy()) {
       Builder.CreateRetVoid();
     } else if (Ty->isStructTy()) {
-      const unsigned Count = Ty->getStructNumElements();
+      const auto Count = Ty->getStructNumElements();
       std::vector<llvm::Value *> Ret(Count);
       for (unsigned I = 0; I < Count; ++I) {
-        const unsigned J = Count - I - 1;
+        const unsigned J = Count - 1 - I;
         Ret[J] = stackPop();
       }
       Builder.CreateAggregateRet(Ret.data(), Count);
@@ -1286,12 +1393,20 @@ public:
     }
   }
 
-  static llvm::Constant *evaluate(const AST::InstrVec &Instrs,
-                                  AOT::Compiler::CompileContext &Context) {
+  static Expect<llvm::Constant *>
+  evaluate(const AST::InstrVec &Instrs,
+           AOT::Compiler::CompileContext &Context) {
     // XXX: assuming Instrs contains only one constant value instruction
     FunctionCompiler FC(Context);
     FC.compile(Instrs);
-    return llvm::cast<llvm::Constant>(FC.Stack.back());
+    if (FC.Stack.size() != 1) {
+      return Unexpect(ErrCode::ConstExprRequired);
+    }
+    auto *Result = llvm::cast_or_null<llvm::Constant>(FC.Stack.back());
+    if (!Result) {
+      return Unexpect(ErrCode::ConstExprRequired);
+    }
+    return Result;
   }
 
 private:
@@ -1301,15 +1416,14 @@ private:
     const auto &Function = std::get<1>(Context.Functions[FuncIndex]);
     const auto &ParamTypes = FuncType.getParamTypes();
 
-    std::vector<llvm::Value *> Args(ParamTypes.size() + 1);
-    Args[0] = Ctx;
+    std::vector<llvm::Value *> Args(ParamTypes.size());
     for (size_t I = 0; I < ParamTypes.size(); ++I) {
       const size_t J = ParamTypes.size() - 1 - I;
-      Args[1 + J] = stackPop();
+      Args[J] = stackPop();
     }
 
-    llvm::Value *Ret = Builder.CreateCall(Function, Args);
-    llvm::Type *Ty = Function->getReturnType();
+    auto *Ret = Builder.CreateCall(Function, Args);
+    auto *Ty = Ret->getType();
     if (Ty->isVoidTy()) {
       // nothing to do
     } else if (Ty->isStructTy()) {
@@ -1320,7 +1434,6 @@ private:
       stackPush(Ret);
     }
 
-    Builder.CreateStore(Builder.CreateLoad(Context.Mem), LocalMemPtr);
     return {};
   }
 
@@ -1328,77 +1441,72 @@ private:
     llvm::Value *Value = stackPop();
     const auto &FuncType = *Context.FunctionTypes[FuncTypeIndex];
     const auto &ParamTypes = FuncType.getParamTypes();
-    std::vector<llvm::Value *> Args(ParamTypes.size() + 1);
-    Args[0] = Ctx;
+    std::vector<llvm::Value *> Args(ParamTypes.size());
     for (size_t I = 0; I < ParamTypes.size(); ++I) {
       const size_t J = ParamTypes.size() - 1 - I;
-      Args[1 + J] = stackPop();
+      Args[J] = stackPop();
     }
 
     std::vector<std::pair<size_t, llvm::Function *>> Table;
     for (uint32_t I = 0; I < Context.Elements.size(); ++I) {
-      const size_t FuncIdx = Context.Elements[I];
-      if (std::get<0>(Context.Functions[FuncIdx]) == FuncTypeIndex) {
+      const auto FuncIdx = Context.Elements[I];
+      const auto FuncTypeIndex2 = std::get<0>(Context.Functions[FuncIdx]);
+      const auto &FuncType2 = *Context.FunctionTypes[FuncTypeIndex2];
+      if (FuncTypeIndex == FuncTypeIndex2 || FuncType == FuncType2) {
         Table.emplace_back(I, std::get<1>(Context.Functions[FuncIdx]));
       }
     }
-    llvm::BasicBlock *OK =
-        llvm::BasicBlock::Create(VMContext, "call_indirect.end", F);
-    llvm::BasicBlock *Error =
-        llvm::BasicBlock::Create(VMContext, "call_indirect.error", F);
-    llvm::SwitchInst *Switch = Builder.CreateSwitch(Value, Error, Table.size());
+    auto *OKBB = llvm::BasicBlock::Create(VMContext, "call_indirect.end", F);
+    auto *Switch = Builder.CreateSwitch(
+        Value, getTrapBB(ErrCode::UndefinedElement), Table.size());
 
     const bool HasReturnValue = !isVoidReturn(FuncType.getReturnTypes());
+    const bool HasMultipleValule = FuncType.getReturnTypes().size() > 1;
     std::vector<std::tuple<std::vector<llvm::Value *>, llvm::BasicBlock *>>
         ReturnValues;
-
-    for (const auto &[Value, Func] : Table) {
-      llvm::BasicBlock *Entry = llvm::BasicBlock::Create(
-          VMContext, "call_indirect." + std::to_string(Value), F);
-      Builder.SetInsertPoint(Entry);
-      llvm::Value *Ret = Builder.CreateCall(Func, Args);
-      Builder.CreateBr(OK);
-      Switch->addCase(Builder.getInt32(Value), Entry);
-      if (HasReturnValue) {
-        if (Ret->getType()->isStructTy()) {
-          ReturnValues.emplace_back(unpackStruct(Builder, Ret), Entry);
-        } else {
-          ReturnValues.emplace_back(std::vector<llvm::Value *>{Ret}, Entry);
-        }
-      }
+    if (HasReturnValue) {
+      ReturnValues.reserve(Table.size());
     }
 
-    Builder.SetInsertPoint(Error);
-    updateInstrCount();
-    Context.callTrap(Builder, Ctx,
-                     Builder.getInt32(uint32_t(ErrCode::Unreachable)));
-    Builder.CreateUnreachable();
+    for (const auto &[Value, Function] : Table) {
+      auto *Entry = llvm::BasicBlock::Create(
+          VMContext, "call_indirect." + std::to_string(Value), F);
+      Builder.SetInsertPoint(Entry);
 
-    Builder.SetInsertPoint(OK);
+      auto *Ret = Builder.CreateCall(Function, Args);
+      if (HasMultipleValule) {
+        ReturnValues.emplace_back(unpackStruct(Builder, Ret), Entry);
+      } else if (HasReturnValue) {
+        ReturnValues.emplace_back(std::vector<llvm::Value *>{Ret}, Entry);
+      }
+      Builder.CreateBr(OKBB);
+      Switch->addCase(Builder.getInt32(Value), Entry);
+    }
+
+    Builder.SetInsertPoint(OKBB);
     if (HasReturnValue) {
       buildPHI(FuncType.getReturnTypes(), ReturnValues);
     }
 
-    Builder.CreateStore(Builder.CreateLoad(Context.Mem), LocalMemPtr);
     return {};
   }
 
-  Expect<void> compileLoadOp(unsigned int Offset, unsigned Alignment,
+  Expect<void> compileLoadOp(unsigned Offset, unsigned Alignment,
                              llvm::Type *LoadTy) {
-    llvm::Value *Off = Builder.CreateZExt(stackPop(), Builder.getInt64Ty());
+    auto *Off = Builder.CreateZExt(stackPop(), Builder.getInt64Ty());
     if (Offset != 0) {
       Off = Builder.CreateAdd(Off, Builder.getInt64(Offset));
     }
-    llvm::Value *VPtr =
-        Builder.CreateInBoundsGEP(Builder.CreateLoad(LocalMemPtr), {Off});
-    llvm::Value *Ptr =
-        Builder.CreateBitCast(VPtr, llvm::PointerType::getUnqual(LoadTy));
-    llvm::LoadInst *LoadInst = Builder.CreateLoad(Ptr);
+
+    auto *VPtr =
+        Builder.CreateInBoundsGEP(Builder.CreateLoad(Context.Mem), {Off});
+    auto *Ptr = Builder.CreateBitCast(VPtr, LoadTy->getPointerTo());
+    auto *LoadInst = Builder.CreateLoad(Ptr);
     LoadInst->setAlignment(Align(UINT64_C(1) << Alignment));
     stackPush(LoadInst);
     return {};
   }
-  Expect<void> compileLoadOp(unsigned int Offset, unsigned Alignment,
+  Expect<void> compileLoadOp(unsigned Offset, unsigned Alignment,
                              llvm::Type *LoadTy, llvm::Type *ExtendTy,
                              bool Signed) {
     if (auto Ret = compileLoadOp(Offset, Alignment, LoadTy); !Ret) {
@@ -1411,49 +1519,51 @@ private:
     }
     return {};
   }
-  Expect<void> compileStoreOp(unsigned int Offset, unsigned Alignment,
+  Expect<void> compileStoreOp(unsigned Offset, unsigned Alignment,
                               llvm::Type *LoadTy, bool Trunc = false) {
-    llvm::Value *V = stackPop();
-    if (Trunc) {
-      V = Builder.CreateTrunc(V, LoadTy);
-    }
-
-    llvm::Value *Off = Builder.CreateZExt(Stack.back(), Builder.getInt64Ty());
-    Stack.pop_back();
+    auto *V = stackPop();
+    auto *Off = Builder.CreateZExt(stackPop(), Builder.getInt64Ty());
     if (Offset != 0) {
       Off = Builder.CreateAdd(Off, Builder.getInt64(Offset));
     }
 
-    llvm::Value *VPtr =
-        Builder.CreateInBoundsGEP(Builder.CreateLoad(LocalMemPtr), {Off});
-    llvm::Value *Ptr =
-        Builder.CreateBitCast(VPtr, llvm::PointerType::getUnqual(LoadTy));
-    llvm::StoreInst *StoreInst = Builder.CreateStore(V, Ptr);
+    if (Trunc) {
+      V = Builder.CreateTrunc(V, LoadTy);
+    }
+    auto *VPtr =
+        Builder.CreateInBoundsGEP(Builder.CreateLoad(Context.Mem), {Off});
+    auto *Ptr = Builder.CreateBitCast(VPtr, LoadTy->getPointerTo());
+    auto *StoreInst = Builder.CreateStore(V, Ptr);
     StoreInst->setAlignment(Align(UINT64_C(1) << Alignment));
     return {};
   }
 
-  std::vector<ValType> resolveBlockType(const BlockType &ResultType) const {
+  std::pair<std::vector<ValType>, std::vector<ValType>>
+  resolveBlockType(const BlockType &ResultType) const {
+    using VecT = std::vector<ValType>;
+    using RetT = std::pair<VecT, VecT>;
     return std::visit(
-        overloaded{[](const ValType &Type) {
+        overloaded{[](const ValType &Type) -> RetT {
                      if (Type == ValType::None) {
-                       return std::vector<ValType>{};
+                       return RetT{};
                      }
-                     return std::vector<ValType>{Type};
+                     return RetT{{}, {Type}};
                    },
-                   [this](const uint32_t &Index) {
-                     const auto &RetTypes =
-                         Context.FunctionTypes[Index]->getReturnTypes();
-                     return std::vector<ValType>(RetTypes.begin(),
-                                                 RetTypes.end());
+                   [this](const uint32_t &Index) -> RetT {
+                     const auto &Type = *Context.FunctionTypes[Index];
+                     return RetT{VecT(Type.getParamTypes().begin(),
+                                      Type.getParamTypes().end()),
+                                 VecT(Type.getReturnTypes().begin(),
+                                      Type.getReturnTypes().end())};
                    }},
         ResultType);
   }
 
   void enterBlock(llvm::BasicBlock *JumpTarget, bool IsForward,
                   const BlockType &ResultType) {
-    ControlStack.emplace_back(Stack.size(), JumpTarget, IsForward,
-                              resolveBlockType(ResultType), 0);
+    auto Type = resolveBlockType(ResultType);
+    ControlStack.emplace_back(Stack.size() - Type.first.size(), JumpTarget,
+                              IsForward, std::move(Type.second), 0);
   }
 
   std::vector<std::tuple<std::vector<llvm::Value *>, llvm::BasicBlock *>>
@@ -1497,15 +1607,18 @@ private:
     }
     std::vector<llvm::Value *> Nodes;
     if (Incomings.size() == 0) {
-      for (llvm::Type *Type : toLLVMTypeVector(Context.Context, RetType)) {
+      const auto &Types = toLLVMTypeVector(VMContext, RetType);
+      Nodes.reserve(Types.size());
+      for (llvm::Type *Type : Types) {
         Nodes.push_back(llvm::UndefValue::get(Type));
       }
     } else if (Incomings.size() == 1) {
       Nodes = std::move(std::get<0>(Incomings.front()));
     } else {
-      const auto &Types = toLLVMTypeVector(Context.Context, RetType);
+      const auto &Types = toLLVMTypeVector(VMContext, RetType);
+      Nodes.reserve(Types.size());
       for (size_t I = 0; I < Types.size(); ++I) {
-        llvm::PHINode *PHIRet = Builder.CreatePHI(Types[I], Incomings.size());
+        auto *PHIRet = Builder.CreatePHI(Types[I], Incomings.size());
         for (auto &[Value, BB] : Incomings) {
           assert(Value.size() == Types.size());
           PHIRet->addIncoming(Value[I], BB);
@@ -1548,7 +1661,7 @@ private:
     assert(!ControlStack.empty() || !Stack.empty());
     assert(ControlStack.empty() ||
            Stack.size() > std::get<kStackSize>(ControlStack.back()));
-    llvm::Value *Value = Stack.back();
+    auto *Value = Stack.back();
     Stack.pop_back();
     return Value;
   }
@@ -1557,9 +1670,8 @@ private:
   llvm::LLVMContext &VMContext;
   std::vector<llvm::Value *> Local;
   std::vector<llvm::Value *> Stack;
-  llvm::Argument *Ctx = nullptr;
-  llvm::Value *LocalMemPtr = nullptr;
   llvm::Value *LocalInstrCount = nullptr;
+  std::unordered_map<ErrCode, llvm::BasicBlock *> TrapBB;
   bool IsUnreachable = false;
   static inline constexpr size_t kStackSize = 0;
   static inline constexpr size_t kJumpBlock = 1;
@@ -1683,35 +1795,10 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
         return {};
       })
       .and_then([&]() -> Expect<void> {
-        /// create ctor
-        llvm::Function *Ctor = llvm::Function::Create(
-            llvm::FunctionType::get(
-                llvm::Type::getVoidTy(Context->Context),
-                {Context->Trap->getType()->getPointerElementType(),
-                 Context->Call->getType()->getPointerElementType(),
-                 Context->MemGrow->getType()->getPointerElementType(),
-                 Context->MemSize->getType()->getPointerElementType()},
-                false),
-            llvm::GlobalValue::ExternalLinkage, "ctor", LLModule.get());
-        Ctor->addFnAttr(llvm::Attribute::StrictFP);
-
-        llvm::IRBuilder<> Builder(
-            llvm::BasicBlock::Create(Context->Context, "entry", Ctor));
-        Builder.setIsFPConstrained(true);
-        Builder.setDefaultConstrainedRounding(RoundingMode::rmToNearest);
-        Builder.setDefaultConstrainedExcept(ExceptionBehavior::ebIgnore);
-        Builder.CreateStore(Ctor->arg_begin(), Context->Trap);
-        Builder.CreateStore(Ctor->arg_begin() + 1, Context->Call);
-        Builder.CreateStore(Ctor->arg_begin() + 2, Context->MemGrow);
-        Builder.CreateStore(Ctor->arg_begin() + 3, Context->MemSize);
-        for (auto &F : Context->Ctors) {
-          Builder.CreateCall(F);
-        }
-        Builder.CreateRetVoid();
-
         /// create wasm.code and wasm.size
         {
-          llvm::Constant *Content = llvm::ConstantDataArray::getString(
+          auto *Int32Ty = llvm::Type::getInt32Ty(VMContext);
+          auto *Content = llvm::ConstantDataArray::getString(
               VMContext,
               llvm::StringRef(reinterpret_cast<const char *>(Data.data()),
                               Data.size()),
@@ -1719,9 +1806,10 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
           new llvm::GlobalVariable(Context->Module, Content->getType(), false,
                                    llvm::GlobalValue::ExternalLinkage, Content,
                                    "wasm.code");
-          new llvm::GlobalVariable(Context->Module, Builder.getInt32Ty(), false,
+          new llvm::GlobalVariable(Context->Module, Int32Ty, false,
                                    llvm::GlobalValue::ExternalLinkage,
-                                   Builder.getInt32(Data.size()), "wasm.size");
+                                   llvm::ConstantInt::get(Int32Ty, Data.size()),
+                                   "wasm.size");
         }
 
         {
@@ -1805,8 +1893,8 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
 
           llvm::ModulePassManager MPM(false);
 
+          MPM.addPass(PB.buildPerModuleDefaultPipeline(llvm::PassBuilder::Oz));
           MPM.addPass(PB.buildPerModuleDefaultPipeline(llvm::PassBuilder::O3));
-          MPM.addPass(llvm::AlwaysInlinerPass());
 
           llvm::legacy::PassManager CodeGenPasses;
           CodeGenPasses.add(llvm::createTargetTransformInfoWrapperPass(
@@ -1829,6 +1917,27 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
           }
 
           MPM.run(*LLModule, MAM);
+
+          {
+            if (auto *Call = LLModule->getGlobalVariable("call")) {
+              Call->setInitializer(llvm::ConstantPointerNull::get(
+                  llvm::cast<llvm::PointerType>(Call->getValueType())));
+              Call->setConstant(false);
+            }
+
+            if (auto *MemGrow = LLModule->getGlobalVariable("memgrow")) {
+              MemGrow->setInitializer(llvm::ConstantPointerNull::get(
+                  llvm::cast<llvm::PointerType>(MemGrow->getValueType())));
+              MemGrow->setConstant(false);
+            }
+
+            if (auto *Mem = LLModule->getGlobalVariable("mem")) {
+              Mem->setInitializer(llvm::ConstantPointerNull::get(
+                  llvm::cast<llvm::PointerType>(Mem->getValueType())));
+              Mem->setConstant(false);
+            }
+          }
+
           {
             int Fd;
             llvm::sys::fs::openFileForWrite("wasm-opt.ll", Fd);
@@ -1879,14 +1988,14 @@ Expect<void> Compiler::compile(const AST::ImportSection &ImportSec) {
     const auto &ExtType = ImpDesc->getExternalType();
     const std::string ModName(ImpDesc->getModuleName());
     const std::string ExtName(ImpDesc->getExternalName());
-    const std::string FullName = '$' + ModName + '.' + ExtName;
-    const std::string FullCtxName = FullName + ".ctx";
+    const std::string FullName =
+        AST::Module::toExportName(ModName + '.' + ExtName);
 
     /// Add the imports into module istance.
     switch (ExtType) {
     case ExternalType::Function: /// Function type index
     {
-      const uint32_t FuncIndex = Context->Functions.size();
+      const auto FuncIndex = Context->Functions.size();
       /// Get the function type index in module.
       unsigned int *TypeIdx = nullptr;
       if (auto Res = ImpDesc->getExternalContent<uint32_t>()) {
@@ -1900,12 +2009,10 @@ Expect<void> Compiler::compile(const AST::ImportSection &ImportSec) {
       const auto &FuncType = *Context->FunctionTypes[*TypeIdx];
 
       llvm::FunctionType *FTy = toLLVMType(VMContext, FuncType);
-      llvm::Function *F = llvm::Function::Create(
-          FTy, llvm::GlobalValue::InternalLinkage, FullName, Context->Module);
+      auto *RTy = FTy->getReturnType();
+      auto *F = llvm::Function::Create(FTy, llvm::Function::InternalLinkage,
+                                       FullName, Context->Module);
       F->addFnAttr(llvm::Attribute::StrictFP);
-      llvm::Type *Ty = FTy->getReturnType();
-
-      llvm::Argument *Ctx = F->arg_begin();
 
       llvm::BasicBlock *Entry = llvm::BasicBlock::Create(VMContext, "entry", F);
       llvm::IRBuilder<> Builder(Entry);
@@ -1913,54 +2020,53 @@ Expect<void> Compiler::compile(const AST::ImportSection &ImportSec) {
       Builder.setDefaultConstrainedRounding(RoundingMode::rmToNearest);
       Builder.setDefaultConstrainedExcept(ExceptionBehavior::ebIgnore);
 
+      const auto ArgSize = FuncType.getParamTypes().size();
+      const auto RetSize =
+          RTy->isVoidTy() ? 0 : FuncType.getReturnTypes().size();
+
       llvm::Value *Args;
-      if (FTy->getNumParams() == 1) {
+      if (ArgSize == 0) {
         Args = llvm::ConstantPointerNull::get(Builder.getInt8PtrTy());
       } else {
-        Args = Builder.CreateAlloca(
-            Builder.getInt8Ty(),
-            Builder.getInt64((FTy->getNumParams() - 1) * 8));
+        Args = Builder.CreateAlloca(Builder.getInt8Ty(),
+                                    Builder.getInt64(ArgSize * 8));
       }
 
       llvm::Value *Rets;
-      if (Ty->isVoidTy()) {
+      if (RetSize == 0) {
         Rets = llvm::ConstantPointerNull::get(Builder.getInt8PtrTy());
-      } else if (Ty->isStructTy()) {
-        Rets = Builder.CreateAlloca(
-            Builder.getInt8Ty(),
-            Builder.getInt64(Ty->getStructNumElements() * 8));
       } else {
-        Rets = Builder.CreateAlloca(Builder.getInt8Ty(), Builder.getInt64(8));
+        Rets = Builder.CreateAlloca(Builder.getInt8Ty(),
+                                    Builder.getInt64(RetSize * 8));
       }
 
-      unsigned I = 0;
-      for (llvm::Argument *Arg = Ctx + 1; Arg != F->arg_end(); ++Arg, ++I) {
+      for (unsigned I = 0; I < ArgSize; ++I) {
+        llvm::Argument *Arg = F->arg_begin() + I;
         llvm::Value *Ptr = Builder.CreateConstInBoundsGEP1_64(Args, I * 8);
         Builder.CreateStore(
-            Arg, Builder.CreateBitCast(
-                     Ptr, llvm::PointerType::getUnqual(Arg->getType())));
+            Arg, Builder.CreateBitCast(Ptr, Arg->getType()->getPointerTo()));
       }
 
-      Context->callCall(Builder, Ctx, Builder.getInt32(FuncIndex), Args, Rets);
+      Builder.CreateCall(Builder.CreateLoad(Context->Call),
+                         {Builder.getInt32(FuncIndex), Args, Rets});
 
-      if (Ty->isVoidTy()) {
+      if (RetSize == 0) {
         Builder.CreateRetVoid();
-      } else if (Ty->isStructTy()) {
-        const unsigned N = Ty->getStructNumElements();
+      } else if (RetSize == 1) {
+        llvm::Value *VPtr = Builder.CreateConstInBoundsGEP1_64(Rets, 0);
+        llvm::Value *Ptr =
+            Builder.CreateBitCast(VPtr, F->getReturnType()->getPointerTo());
+        Builder.CreateRet(Builder.CreateLoad(Ptr));
+      } else {
         std::vector<llvm::Value *> Ret;
-        Ret.reserve(N);
-        for (unsigned I = 0; I < N; ++I) {
+        Ret.reserve(RetSize);
+        for (unsigned I = 0; I < RetSize; ++I) {
           llvm::Value *VPtr = Builder.CreateConstInBoundsGEP1_64(Rets, I);
           llvm::Value *Ptr = Builder.CreateBitCast(
-              VPtr, llvm::PointerType::getUnqual(Ty->getStructElementType(I)));
+              VPtr, RTy->getStructElementType(I)->getPointerTo());
           Ret.push_back(Builder.CreateLoad(Ptr));
         }
-        Builder.CreateAggregateRet(Ret.data(), N);
-      } else {
-        llvm::Value *VPtr = Builder.CreateConstInBoundsGEP1_64(Rets, 0);
-        llvm::Value *Ptr = Builder.CreateBitCast(
-            VPtr, llvm::PointerType::getUnqual(F->getReturnType()));
-        Builder.CreateRet(Builder.CreateLoad(Ptr));
+        Builder.CreateAggregateRet(Ret.data(), RetSize);
       }
 
       Context->Functions.emplace_back(*TypeIdx, F, nullptr);
@@ -1993,53 +2099,57 @@ Expect<void> Compiler::compile(const AST::ExportSection &ExportSec) {
   for (const auto &ExpDesc : ExportSec.getContent()) {
     switch (ExpDesc->getExternalType()) {
     case ExternalType::Function: {
-      llvm::Function *Wrapper = llvm::Function::Create(
+      auto *Wrapper = llvm::Function::Create(
           llvm::FunctionType::get(llvm::Type::getVoidTy(VMContext),
                                   {llvm::Type::getInt8PtrTy(VMContext),
-                                   llvm::Type::getInt8PtrTy(VMContext),
                                    llvm::Type::getInt8PtrTy(VMContext)},
                                   false),
           llvm::GlobalValue::ExternalLinkage,
-          "$" + std::string(ExpDesc->getExternalName()), Context->Module);
+          AST::Module::toExportName(ExpDesc->getExternalName()),
+          Context->Module);
       Wrapper->addFnAttr(llvm::Attribute::StrictFP);
-      llvm::Argument *Ctx = Wrapper->arg_begin();
-      llvm::Argument *RawArgs = Ctx + 1;
-      llvm::Argument *RawRets = RawArgs + 1;
+      llvm::Argument *RawArgs = Wrapper->arg_begin();
+      llvm::Argument *RawRets = Wrapper->arg_begin() + 1;
       llvm::IRBuilder<> Builder(
-          llvm::BasicBlock::Create(Ctx->getContext(), "entry", Wrapper));
+          llvm::BasicBlock::Create(Wrapper->getContext(), "entry", Wrapper));
       Builder.setIsFPConstrained(true);
       Builder.setDefaultConstrainedRounding(RoundingMode::rmToNearest);
       Builder.setDefaultConstrainedExcept(ExceptionBehavior::ebIgnore);
       llvm::Function *F =
           std::get<1>(Context->Functions[ExpDesc->getExternalIndex()]);
-      llvm::Type *Ty = F->getReturnType();
 
-      std::vector<llvm::Value *> Args = {Ctx};
-      unsigned I = 0;
-      for (llvm::Argument *Arg = F->arg_begin() + 1; Arg != F->arg_end();
-           ++Arg, ++I) {
+      auto *RTy = F->getReturnType();
+      const size_t ArgCount = F->arg_size();
+      const size_t RetCount =
+          RTy->isVoidTy()
+              ? 0
+              : (RTy->isStructTy() ? RTy->getStructNumElements() : 1);
+      std::vector<llvm::Value *> Args;
+      Args.reserve(F->arg_size());
+      for (size_t I = 0; I < ArgCount; ++I) {
+        llvm::Argument *Arg = F->arg_begin() + I;
         llvm::Value *VPtr = Builder.CreateConstInBoundsGEP1_64(RawArgs, I * 8);
-        llvm::Value *Ptr = Builder.CreateBitCast(
-            VPtr, llvm::PointerType::getUnqual(Arg->getType()));
+        llvm::Value *Ptr =
+            Builder.CreateBitCast(VPtr, Arg->getType()->getPointerTo());
         Args.push_back(Builder.CreateLoad(Ptr));
       }
 
-      llvm::Value *Ret = Builder.CreateCall(F, Args);
-      if (Ty->isVoidTy()) {
+      auto Ret = Builder.CreateCall(F, Args);
+      if (RTy->isVoidTy()) {
         // nothing to do
-      } else if (Ty->isStructTy()) {
-        const unsigned N = Ty->getStructNumElements();
-        for (unsigned I = 0; I < N; ++I) {
+      } else if (RTy->isStructTy()) {
+        auto Rets = unpackStruct(Builder, Ret);
+        for (size_t I = 0; I < RetCount; ++I) {
           llvm::Value *VPtr =
               Builder.CreateConstInBoundsGEP1_64(RawRets, I * 8);
-          llvm::Value *Ptr = Builder.CreateBitCast(
-              VPtr, llvm::PointerType::getUnqual(Ty->getStructElementType(I)));
-          Builder.CreateStore(Builder.CreateExtractValue(Ret, {I}), Ptr);
+          llvm::Value *Ptr =
+              Builder.CreateBitCast(VPtr, Rets[I]->getType()->getPointerTo());
+          Builder.CreateStore(Rets[I], Ptr);
         }
       } else {
         llvm::Value *VPtr = Builder.CreateConstInBoundsGEP1_64(RawRets, 0);
         llvm::Value *Ptr =
-            Builder.CreateBitCast(VPtr, llvm::PointerType::getUnqual(Ty));
+            Builder.CreateBitCast(VPtr, Ret->getType()->getPointerTo());
         Builder.CreateStore(Ret, Ptr);
       }
       Builder.CreateRetVoid();
@@ -2049,7 +2159,7 @@ Expect<void> Compiler::compile(const AST::ExportSection &ExportSec) {
     case ExternalType::Global: {
       llvm::GlobalVariable *G = Context->Globals[ExpDesc->getExternalIndex()];
       G->setLinkage(llvm::GlobalValue::ExternalLinkage);
-      G->setName("$" + std::string(ExpDesc->getExternalName()));
+      G->setName(AST::Module::toExportName(ExpDesc->getExternalName()));
       break;
     }
     case ExternalType::Memory: {
@@ -2069,14 +2179,16 @@ Expect<void> Compiler::compile(const AST::ExportSection &ExportSec) {
 
 Expect<void> Compiler::compile(const AST::GlobalSection &GlobalSec) {
   for (size_t I = 0; I < GlobalSec.getContent().size(); ++I) {
-    const SSVM::ValType &ValType =
+    auto Temp = FunctionCompiler::evaluate(
+        GlobalSec.getContent()[I]->getInstrs(), *Context);
+    if (!Temp) {
+      return Unexpect(Temp);
+    }
+    const auto &ValType =
         GlobalSec.getContent()[I]->getGlobalType()->getValueType();
-    llvm::GlobalVariable *G = new llvm::GlobalVariable(
+    auto *G = new llvm::GlobalVariable(
         Context->Module, toLLVMType(Context->Context, ValType), false,
-        llvm::GlobalValue::InternalLinkage,
-        FunctionCompiler::evaluate(GlobalSec.getContent()[I]->getInstrs(),
-                                   *Context),
-        "g." + std::to_string(I));
+        llvm::GlobalValue::InternalLinkage, *Temp, "g." + std::to_string(I));
     Context->Globals.push_back(G);
   }
   return {};
@@ -2087,59 +2199,9 @@ Expect<void> Compiler::compile(const AST::MemorySection &MemorySection,
   if (MemorySection.getContent().size() != 1) {
     return Unexpect(ErrCode::MultiMemories);
   }
-
-  /*
-  auto &VMContext = Context->Context;
-  llvm::Type *Int32Ty = llvm::Type::getInt32Ty(VMContext);
-
-  // create variable for recording limit
-  {
-    const auto &Limit = MemorySection.getContent()[0]->getLimit();
-    const auto Min = Limit->getMin();
-    const auto Max = Limit->getMax();
-    new llvm::GlobalVariable(Context->Module, Int32Ty, true,
-                             llvm::GlobalValue::ExternalLinkage,
-                             llvm::ConstantInt::get(Int32Ty, Min), "memMin");
-    new llvm::GlobalVariable(Context->Module, Int32Ty, true,
-                             llvm::GlobalValue::ExternalLinkage,
-                             llvm::ConstantInt::get(Int32Ty, Max), "memMax");
-  }
-
-  std::vector<char> ResultData;
-  for (const auto &DataSeg : DataSec.getContent()) {
-    llvm::Constant *Temp =
-        FunctionCompiler::evaluate(DataSeg->getInstrs(), *Context);
-    const uint64_t Offset = llvm::cast<llvm::ConstantInt>(Temp)->getZExtValue();
-    const auto &Data = DataSeg->getData();
-
-    if (ResultData.size() < Offset + Data.size()) {
-      ResultData.resize(Offset + Data.size());
-    }
-    std::copy(Data.cbegin(), Data.cend(), ResultData.begin() + Offset);
-  }
-  llvm::Function *Ctor = llvm::Function::Create(
-      llvm::FunctionType::get(llvm::Type::getVoidTy(VMContext), false),
-      llvm::GlobalValue::InternalLinkage, "mem.ctor", Context->Module);
-
-  llvm::IRBuilder<> Builder(
-      llvm::BasicBlock::Create(Context->Context, "entry", Ctor));
-  Builder.setIsFPConstrained(true);
-  Builder.setDefaultConstrainedRounding(RoundingMode::rmToNearest);
-  Builder.setDefaultConstrainedExcept(ExceptionBehavior::ebIgnore);
-  llvm::Constant *Content = llvm::ConstantDataArray::getString(
-      VMContext, llvm::StringRef(ResultData.data(), ResultData.size()), false);
-  llvm::GlobalVariable *GV =
-      new llvm::GlobalVariable(Context->Module, Content->getType(), true,
-                               llvm::GlobalVariable::InternalLinkage, Content);
-
-  Builder.CreateMemCpy(
-      Builder.CreateInBoundsGEP(Builder.CreateLoad(Context->Mem),
-                                Builder.getInt32(0)),
-      8, GV, 8, Builder.getInt32(ResultData.size()));
-  Builder.CreateRetVoid();
-
-  Context->Ctors.push_back(Ctor);
-  */
+  const auto &Limit = *MemorySection.getContent().front()->getLimit();
+  Context->MemMin = Limit.getMin();
+  Context->MemMax = Limit.hasMax() ? Limit.getMax() : 65536;
   return {};
 }
 
@@ -2150,9 +2212,12 @@ Expect<void> Compiler::compile(const AST::TableSection &TableSection,
   }
   auto &Elements = Context->Elements;
   for (const auto &Element : ElementSection.getContent()) {
-    llvm::Constant *Temp =
-        FunctionCompiler::evaluate(Element->getInstrs(), *Context);
-    const uint64_t Offset = llvm::cast<llvm::ConstantInt>(Temp)->getZExtValue();
+    auto Temp = FunctionCompiler::evaluate(Element->getInstrs(), *Context);
+    if (!Temp) {
+      return Unexpect(Temp);
+    }
+    const uint64_t Offset =
+        llvm::cast<llvm::ConstantInt>(*Temp)->getZExtValue();
     const auto &FuncIdxes = Element->getFuncIdxes();
     if (Elements.size() < Offset + FuncIdxes.size()) {
       Elements.resize(Offset + FuncIdxes.size());
@@ -2174,10 +2239,11 @@ Expect<void> Compiler::compile(const AST::FunctionSection &FuncSec,
       return Unexpect(ErrCode::InvalidFuncTypeIdx);
     }
     const auto &FuncType = *Context->FunctionTypes[TypeIdx];
-    llvm::FunctionType *FTy = toLLVMType(Context->Context, FuncType);
-    llvm::Function *F = llvm::Function::Create(
-        FTy, llvm::GlobalValue::InternalLinkage,
-        "f" + std::to_string(Context->Functions.size()), Context->Module);
+    const auto FuncID = Context->Functions.size();
+    auto *FTy = toLLVMType(Context->Context, FuncType);
+    auto *F =
+        llvm::Function::Create(FTy, llvm::Function::InternalLinkage,
+                               "f" + std::to_string(FuncID), Context->Module);
     F->addFnAttr(llvm::Attribute::StrictFP);
 
     Context->Functions.emplace_back(TypeIdx, F, Code.get());

--- a/lib/ast/module.cpp
+++ b/lib/ast/module.cpp
@@ -179,7 +179,7 @@ Expect<void> Module::loadBinary(FileMgr &Mgr) {
 Expect<void> Module::loadCompiled(LDMgr &Mgr) {
   if (ExportSec) {
     for (auto &ExpDesc : ExportSec->getContent()) {
-      const std::string Name = '$' + std::string(ExpDesc->getExternalName());
+      const std::string Name = toExportName(ExpDesc->getExternalName());
       switch (ExpDesc->getExternalType()) {
       case ExternalType::Function:
       case ExternalType::Global:

--- a/lib/interpreter/instantiate/module.cpp
+++ b/lib/interpreter/instantiate/module.cpp
@@ -161,11 +161,10 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     }
   }
 
-  /// Call Ctor for compiled module
-  if (auto CtorFunc = Mod.getCtor(); CtorFunc != nullptr) {
-    CtorFunc(Interpreter::trapProxy, Interpreter::callProxy,
-             Interpreter::memGrowProxy, Interpreter::memSizeProxy);
-  }
+  /// Setup callbacks for compiled module
+  Mod.setTrapCodeProxy(&Interpreter::TrapCodeProxy);
+  Mod.setCallProxy(&Interpreter::callProxy);
+  Mod.setMemGrowProxy(&Interpreter::memGrowProxy);
 
   /// Instantiate StartSection (StartSec)
   const AST::StartSection *StartSec = Mod.getStartSection();

--- a/lib/interpreter/interpreter.cpp
+++ b/lib/interpreter/interpreter.cpp
@@ -89,7 +89,7 @@ Interpreter::invoke(Runtime::StoreManager &StoreMgr, const uint32_t FuncAddr,
   const auto &FuncType = FuncInst->getFuncType();
   if (FuncType.Params.size() > Params.size()) {
     std::vector<ValType> GotParams;
-    for (auto I = 0; I < Params.size(); ++I) {
+    for (size_t I = 0; I < Params.size(); ++I) {
       GotParams.push_back(FuncType.Params[I]);
     }
     LOG(ERROR) << ErrCode::FuncSigMismatch;
@@ -98,7 +98,7 @@ Interpreter::invoke(Runtime::StoreManager &StoreMgr, const uint32_t FuncAddr,
     return Unexpect(ErrCode::FuncSigMismatch);
   } else if (FuncType.Params.size() < Params.size()) {
     std::vector<ValType> GotParams = FuncType.Params;
-    for (auto I = FuncType.Params.size(); I < Params.size(); ++I) {
+    for (size_t I = FuncType.Params.size(); I < Params.size(); ++I) {
       GotParams.push_back(ValType::I32);
     }
     LOG(ERROR) << ErrCode::FuncSigMismatch;

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -82,8 +82,12 @@ Loader::parseModule(std::string_view FilePath) {
       return Unexpect(Code);
     }
     if (auto Res = Mod->loadCompiled(LMgr)) {
-      Mod->setCtor(
-          reinterpret_cast<AST::Module::Ctor>(LMgr.getRawSymbol("ctor")));
+      Mod->setTrapCodeProxySymbol(
+          static_cast<AST::Module::TrapCodeProxy *>(LMgr.getRawSymbol("code")));
+      Mod->setCallProxySymbol(
+          static_cast<AST::Module::CallProxy *>(LMgr.getRawSymbol("call")));
+      Mod->setMemGrowProxySymbol(static_cast<AST::Module::MemGrowProxy *>(
+          LMgr.getRawSymbol("memgrow")));
       return Mod;
     } else {
       LOG(ERROR) << ErrInfo::InfoFile(FilePath);

--- a/tools/ssvm-aot/CMakeLists.txt
+++ b/tools/ssvm-aot/CMakeLists.txt
@@ -8,6 +8,7 @@ install(TARGETS ssvmc EXPORT ssvm DESTINATION bin)
 target_link_libraries(ssvmc
   PRIVATE
   ssvmLoader
+  ssvmValidator
   ssvmAOT
   std::filesystem
 )

--- a/tools/ssvm-aot/ssvmc.cpp
+++ b/tools/ssvm-aot/ssvmc.cpp
@@ -2,6 +2,7 @@
 #include "aot/compiler.h"
 #include "loader/loader.h"
 #include "support/filesystem.h"
+#include "validator/validator.h"
 #include <iostream>
 
 int main(int Argc, char *Argv[]) {
@@ -35,11 +36,22 @@ int main(int Argc, char *Argv[]) {
     return EXIT_FAILURE;
   }
 
-  SSVM::AOT::Compiler Compiler;
-  if (auto Res = Compiler.compile(Data, *Module, OutputPath); !Res) {
-    const auto Err = static_cast<uint32_t>(Res.error());
-    std::cout << "Compile failed. Error code:" << Err << std::endl;
-    return EXIT_FAILURE;
+  {
+    SSVM::Validator::Validator ValidatorEngine;
+    if (auto Res = ValidatorEngine.validate(*Module); !Res) {
+      const auto Err = static_cast<uint32_t>(Res.error());
+      std::cout << "Validate failed. Error code:" << Err << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  {
+    SSVM::AOT::Compiler Compiler;
+    if (auto Res = Compiler.compile(Data, *Module, OutputPath); !Res) {
+      const auto Err = static_cast<uint32_t>(Res.error());
+      std::cout << "Compile failed. Error code:" << Err << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
* Use mmap for memory allocation
* Remove Ctor
* Add dummy check for DivideByZero check
* Add check for floating point truncation
* Mangling names for outstanding import/export names
* Register signal handler before entering compiled function to handle
  errors in compiled function
* Move exra `ctx` argument for all compiled function to static variable
  `This`
* Set global variable in compiled module to extern constant for
  optimization, and change back after optimization done
* Validate module before compiling