### PR TITLE
[Misc] Add support for toggle enable and disable different proposal

### DIFF
--- a/include/common/errcode.h
+++ b/include/common/errcode.h
@@ -69,10 +69,11 @@ enum class ErrCode : uint8_t {
   DupExportName = 0x4E,      /// Export name conflicted
   ImmutableGlobal = 0x4F,    /// Tried to store to const global value
   InvalidResultArity = 0x50, /// Invalid result arity in select t* instruction
-  MultiMemories = 0x51,      /// #Memories > 1
-  InvalidLimit = 0x52,       /// Invalid Limit grammar
-  InvalidMemPages = 0x53,    /// Memory pages > 65536
-  InvalidStartFunc = 0x54,   /// Invalid start function signature
+  MultiTables = 0x51,        /// #Tables > 1
+  MultiMemories = 0x52,      /// #Memories > 1
+  InvalidLimit = 0x53,       /// Invalid Limit grammar
+  InvalidMemPages = 0x54,    /// Memory pages > 65536
+  InvalidStartFunc = 0x55,   /// Invalid start function signature
   /// Instantiation phase
   ModuleNameConflict = 0x60,     /// Module name conflicted when importing.
   IncompatibleImportType = 0x61, /// Import matching failed
@@ -128,6 +129,7 @@ static inline std::unordered_map<ErrCode, std::string> ErrCodeStr = {
     {ErrCode::DupExportName, "duplicate export name"},
     {ErrCode::ImmutableGlobal, "global is immutable"},
     {ErrCode::InvalidResultArity, "invalid result arity"},
+    {ErrCode::MultiTables, "multiple tables"},
     {ErrCode::MultiMemories, "multiple memories"},
     {ErrCode::InvalidLimit, "size minimum must not be greater than maximum"},
     {ErrCode::InvalidMemPages,

--- a/include/common/errinfo.h
+++ b/include/common/errinfo.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "astdef.h"
+#include "proposal.h"
 #include "types.h"
 #include "value.h"
 
@@ -353,6 +354,15 @@ struct InfoBoundary {
   uint64_t Offset;
   uint32_t Size;
   uint32_t Limit;
+};
+
+struct InfoProposal {
+  InfoProposal() = default;
+  InfoProposal(Proposal P) noexcept : P(P) {}
+
+  friend std::ostream &operator<<(std::ostream &OS,
+                                  const struct InfoProposal &Rhs);
+  Proposal P;
 };
 
 } // namespace ErrInfo

--- a/include/common/proposal.h
+++ b/include/common/proposal.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//===-- ssvm/common/proposal.h - proposal consiguration class -------------===//
+//
+// Part of the SSVM Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contents the configuration class.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include <bitset>
+#include <cstdint>
+
+namespace SSVM {
+
+/// Wasm Proposal enum class.
+enum class Proposal : uint8_t {
+  Annotations = 0,
+  BulkMemoryOperations,
+  ExceptionHandling,
+  FunctionReferences,
+  Memory64,
+  ReferenceTypes,
+  SIMD,
+  TailCall,
+  Threads,
+  Max,
+};
+
+class ProposalConfigure {
+public:
+  template <typename... ArgsT> ProposalConfigure(ArgsT... Args) noexcept {
+    (addProposal(Args), ...);
+  }
+
+  void addProposal(const Proposal Type) noexcept {
+    Proposals.set(static_cast<uint8_t>(Type));
+  }
+
+  void removeProposal(const Proposal Type) noexcept {
+    Proposals.reset(static_cast<uint8_t>(Type));
+  }
+
+  bool hasProposal(const Proposal Type) const noexcept {
+    return Proposals.test(static_cast<uint8_t>(Type));
+  }
+
+private:
+  std::bitset<static_cast<uint8_t>(Proposal::Max)> Proposals;
+};
+
+} // namespace SSVM

--- a/include/common/proposal.h
+++ b/include/common/proposal.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//===-- ssvm/common/proposal.h - proposal consiguration class -------------===//
+//===-- ssvm/common/proposal.h - proposal configuration class -------------===//
 //
 // Part of the SSVM Project.
 //
@@ -13,6 +13,8 @@
 
 #include <bitset>
 #include <cstdint>
+#include <string_view>
+#include <unordered_map>
 
 namespace SSVM {
 
@@ -29,6 +31,9 @@ enum class Proposal : uint8_t {
   Threads,
   Max,
 };
+
+/// Proposal name enumeration string mapping.
+extern const std::unordered_map<Proposal, std::string_view> ProposalStr;
 
 class ProposalConfigure {
 public:

--- a/include/common/roundeven.h
+++ b/include/common/roundeven.h
@@ -32,7 +32,7 @@
 namespace SSVM {
 namespace detail {
 
-extern "C" inline float roundevenf(float Value) {
+inline float roundevenf(float Value) {
 #if defined(HAVE_BUILTIN_ROUNDEVEN)
   return __builtin_roundevenf(Value);
 #elif defined(__AVX512F__)
@@ -57,7 +57,7 @@ extern "C" inline float roundevenf(float Value) {
 #endif
 }
 
-extern "C" inline double roundeven(double Value) noexcept {
+inline double roundeven(double Value) noexcept {
 #if defined(HAVE_BUILTIN_ROUNDEVEN)
   return __builtin_roundeven(Value);
 #elif defined(__AVX512F__)

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -166,6 +166,11 @@ private:
                          Runtime::Instance::ModuleInstance &ModInst,
                          const AST::ElementSection &ElemSec);
 
+  /// Initialize memory with Data Instances.
+  Expect<void> initMemory(Runtime::StoreManager &StoreMgr,
+                          Runtime::Instance::ModuleInstance &ModInst,
+                          const AST::DataSection &DataSec);
+
   /// Instantiation of Data Instances.
   Expect<void> instantiate(Runtime::StoreManager &StoreMgr,
                            Runtime::Instance::ModuleInstance &ModInst,

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -15,6 +15,7 @@
 #include "ast/instruction.h"
 #include "ast/module.h"
 #include "common/errcode.h"
+#include "common/proposal.h"
 #include "common/statistics.h"
 #include "common/value.h"
 #include "runtime/importobj.h"
@@ -82,7 +83,9 @@ using TypeNN =
 /// Executor flow control class.
 class Interpreter {
 public:
-  Interpreter(Statistics::Statistics *S = nullptr) : Stat(S) {
+  Interpreter(const ProposalConfigure &PConf,
+              Statistics::Statistics *S = nullptr)
+      : PConf(PConf), Stat(S) {
     assert(This == nullptr);
     This = this;
     if (Stat) {
@@ -457,6 +460,8 @@ public:
 private:
   enum class InstantiateMode : uint8_t { Instantiate = 0, ImportWasm };
 
+  /// Proposal configure
+  const ProposalConfigure &PConf;
   /// Instantiate mode
   InstantiateMode InsMode;
   /// Stack

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -14,6 +14,7 @@
 
 #include "ast/module.h"
 #include "common/errcode.h"
+#include "common/proposal.h"
 
 #include <string>
 #include <vector>
@@ -24,7 +25,7 @@ namespace Loader {
 /// Loader flow control class.
 class Loader {
 public:
-  Loader() = default;
+  Loader(const ProposalConfigure &PConf) : PConf(PConf) {}
   ~Loader() = default;
 
   /// Load data from file path.
@@ -37,6 +38,7 @@ public:
   Expect<std::unique_ptr<AST::Module>> parseModule(Span<const uint8_t> Code);
 
 private:
+  const ProposalConfigure &PConf;
   FileMgrFStream FSMgr;
   FileMgrVector FVMgr;
   LDMgr LMgr;

--- a/include/runtime/instance/data.h
+++ b/include/runtime/instance/data.h
@@ -23,7 +23,11 @@ namespace Instance {
 class DataInstance {
 public:
   DataInstance() = delete;
-  DataInstance(Span<const Byte> Init) : Data(Init.begin(), Init.end()) {}
+  DataInstance(const uint32_t Offset, Span<const Byte> Init)
+      : Off(Offset), Data(Init.begin(), Init.end()) {}
+
+  /// Get offset in data instance.
+  uint32_t getOffset() const noexcept { return Off; }
 
   /// Get data in data instance.
   Span<const Byte> getData() const noexcept { return Data; }
@@ -34,6 +38,7 @@ public:
 private:
   /// \name Data of data instance.
   /// @{
+  const uint32_t Off;
   std::vector<Byte> Data;
   /// @}
 };

--- a/include/runtime/instance/elem.h
+++ b/include/runtime/instance/elem.h
@@ -24,8 +24,12 @@ namespace Instance {
 class ElementInstance {
 public:
   ElementInstance() = delete;
-  ElementInstance(const RefType EType, Span<const ValVariant> Init)
-      : Type(EType), Refs(Init.begin(), Init.end()) {}
+  ElementInstance(const uint32_t Offset, const RefType EType,
+                  Span<const ValVariant> Init)
+      : Off(Offset), Type(EType), Refs(Init.begin(), Init.end()) {}
+
+  /// Get offset in element instance.
+  uint32_t getOffset() const noexcept { return Off; }
 
   /// Get reference type of element instance.
   RefType getRefType() const { return Type; }
@@ -39,6 +43,7 @@ public:
 private:
   /// \name Data of element instance.
   /// @{
+  const uint32_t Off;
   const RefType Type;
   std::vector<ValVariant> Refs;
   /// @}

--- a/include/validator/formchecker.h
+++ b/include/validator/formchecker.h
@@ -15,6 +15,7 @@
 #include "ast/instruction.h"
 #include "ast/module.h"
 #include "common/errcode.h"
+#include "common/proposal.h"
 #include "common/span.h"
 #include "common/types.h"
 #include "common/value.h"
@@ -39,7 +40,7 @@ static inline constexpr bool isRefType(const VType V) {
 
 class FormChecker {
 public:
-  FormChecker() = default;
+  FormChecker(const ProposalConfigure &PConf) noexcept : PConf(PConf) {}
   ~FormChecker() = default;
 
   void reset(bool CleanGlobal = false);
@@ -133,6 +134,8 @@ private:
   Expect<std::pair<Span<const VType>, Span<const VType>>>
   resolveBlockType(std::vector<VType> &Buffer, BlockType Type);
 
+  /// Proposal configure
+  const ProposalConfigure &PConf;
   /// Contexts.
   std::vector<std::pair<std::vector<VType>, std::vector<VType>>> Types;
   std::vector<uint32_t> Funcs;

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -14,6 +14,7 @@
 
 #include "ast/module.h"
 #include "common/errcode.h"
+#include "common/proposal.h"
 #include "formchecker.h"
 
 #include <memory>
@@ -25,7 +26,7 @@ namespace Validator {
 /// Validator flow control class.
 class Validator {
 public:
-  Validator() = default;
+  Validator(const ProposalConfigure &PConf) noexcept : PConf(PConf) {}
   ~Validator() = default;
 
   /// Validate AST::Module.
@@ -66,6 +67,9 @@ private:
                                  Span<const ValType> Returns);
 
   static inline const uint32_t LIMIT_MEMORYTYPE = 1U << 16;
+  /// Proposal configure
+  const ProposalConfigure &PConf;
+  /// Formal checker
   FormChecker Checker;
 };
 

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -26,7 +26,8 @@ namespace Validator {
 /// Validator flow control class.
 class Validator {
 public:
-  Validator(const ProposalConfigure &PConf) noexcept : PConf(PConf) {}
+  Validator(const ProposalConfigure &PConf) noexcept
+      : PConf(PConf), Checker(PConf) {}
   ~Validator() = default;
 
   /// Validate AST::Module.

--- a/include/vm/configure.h
+++ b/include/vm/configure.h
@@ -12,8 +12,7 @@
 #pragma once
 
 #include <bitset>
-#include <memory>
-#include <string>
+#include <cstdint>
 
 namespace SSVM {
 namespace VM {
@@ -23,17 +22,22 @@ public:
   /// VM type enum class.
   enum class VMType : uint8_t { Wasm = 0, Wasi, SSVM_Process, Max };
 
-  Configure() { addVMType(VMType::Wasm); }
-  ~Configure() = default;
+  Configure() noexcept { addVMType(VMType::Wasm); }
 
-  void addVMType(const VMType Type) { Types.set(uint8_t(Type)); }
+  void addVMType(const VMType Type) noexcept {
+    Types.set(static_cast<uint8_t>(Type));
+  }
 
-  void removeVMType(const VMType Type) { Types.reset(uint8_t(Type)); }
+  void removeVMType(const VMType Type) noexcept {
+    Types.reset(static_cast<uint8_t>(Type));
+  }
 
-  bool hasVMType(const VMType Type) const { return Types.test(uint8_t(Type)); }
+  bool hasVMType(const VMType Type) const noexcept {
+    return Types.test(static_cast<uint8_t>(Type));
+  }
 
 private:
-  std::bitset<uint8_t(VMType::Max)> Types;
+  std::bitset<static_cast<uint8_t>(VMType::Max)> Types;
 };
 
 } // namespace VM

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "common/errcode.h"
+#include "common/proposal.h"
 #include "common/types.h"
 #include "common/value.h"
 #include "configure.h"
@@ -34,8 +35,9 @@ namespace VM {
 class VM {
 public:
   VM() = delete;
-  VM(Configure &InputConfig);
-  VM(Configure &InputConfig, Runtime::StoreManager &S);
+  VM(const ProposalConfigure &PConf, const Configure &InputConfig);
+  VM(const ProposalConfigure &PConf, const Configure &InputConfig,
+     Runtime::StoreManager &S);
   ~VM() = default;
 
   /// ======= Functions can be called before instantiated stage. =======
@@ -107,7 +109,7 @@ private:
                                               Span<const ValVariant> Params);
 
   /// VM environment.
-  Configure &Config;
+  const Configure &Config;
   Statistics::Statistics Stat;
   VMStage Stage;
 

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -1098,7 +1098,8 @@ public:
       break;
     case OpCode::I32__trunc_f64_s:
       compileSignedTrunc(
-          llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(-0x1p+31)),
+          llvm::ConstantFP::get(Builder.getContext(),
+                                llvm::APFloat(-0x1.00000001fffffp+31)),
           llvm::ConstantFP::get(Builder.getContext(), llvm::APFloat(0x1p+31)),
           Context.Int32Ty);
       break;

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_library(ssvmCommon
   hexstr.cpp
   log.cpp
+  proposal.cpp
 )
 
 target_link_libraries(ssvmCommon

--- a/lib/common/log.cpp
+++ b/lib/common/log.cpp
@@ -254,5 +254,15 @@ std::ostream &operator<<(std::ostream &OS, const struct InfoBoundary &Rhs) {
   return OS;
 }
 
+std::ostream &operator<<(std::ostream &OS, const struct InfoProposal &Rhs) {
+  if (auto Iter = ProposalStr.find(Rhs.P); Iter != ProposalStr.end()) {
+    OS << "    This instruction requires enabling proposal " << Iter->second;
+  } else {
+    OS << "    Unknown proposal, Code "
+       << convertUIntToHexStr(static_cast<uint32_t>(Rhs.P));
+  }
+  return OS;
+}
+
 } // namespace ErrInfo
 } // namespace SSVM

--- a/lib/common/proposal.cpp
+++ b/lib/common/proposal.cpp
@@ -1,0 +1,17 @@
+#include "common/proposal.h"
+namespace SSVM {
+
+using namespace std::literals::string_view_literals;
+/// Proposal name enumeration string mapping.
+const std::unordered_map<Proposal, std::string_view> ProposalStr = {
+    {Proposal::Annotations, "annotations"sv},
+    {Proposal::BulkMemoryOperations, "bulk-memory-operations"sv},
+    {Proposal::ExceptionHandling, "exception-handling"sv},
+    {Proposal::FunctionReferences, "function-references"sv},
+    {Proposal::Memory64, "memory64"sv},
+    {Proposal::ReferenceTypes, "reference-types"sv},
+    {Proposal::SIMD, "simd"sv},
+    {Proposal::TailCall, "tail-call"sv},
+    {Proposal::Threads, "threads"sv}};
+
+} // namespace SSVM

--- a/lib/interpreter/engine/engine.cpp
+++ b/lib/interpreter/engine/engine.cpp
@@ -1121,7 +1121,9 @@ Interpreter::enterFunction(Runtime::StoreManager &StoreMgr,
     TrapJump = std::move(OldTrapJump);
 
     if (Status != 0) {
-      return Unexpect(ErrCode(uint8_t(Status)));
+      ErrCode Code = static_cast<ErrCode>(Status);
+      LOG(ERROR) << Code;
+      return Unexpect(Code);
     }
 
     for (uint32_t I = 0; I < Rets.size(); ++I) {

--- a/lib/interpreter/instantiate/data.cpp
+++ b/lib/interpreter/instantiate/data.cpp
@@ -48,6 +48,9 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
                                        DataInst->getData().size());
           !Res) {
         LOG(ERROR) << ErrInfo::InfoAST(DataSeg->NodeAttr);
+        if (Res.error() == ErrCode::MemoryOutOfBounds) {
+          return Unexpect(ErrCode::DataSegDoesNotFit);
+        }
         return Unexpect(Res);
       }
 

--- a/lib/interpreter/instantiate/data.cpp
+++ b/lib/interpreter/instantiate/data.cpp
@@ -27,13 +27,16 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       }
       Offset = retrieveValue<uint32_t>(StackMgr.pop());
 
-      /// Memory index should be 0. Checked in validation phase.
-      auto *MemInst = getMemInstByIdx(StoreMgr, DataSeg->getIdx());
-      /// Check data fits.
-      if (!MemInst->checkAccessBound(Offset, DataSeg->getData().size())) {
-        LOG(ERROR) << ErrCode::DataSegDoesNotFit;
-        LOG(ERROR) << ErrInfo::InfoAST(DataSeg->NodeAttr);
-        return Unexpect(ErrCode::DataSegDoesNotFit);
+      /// Check boundary unless ReferenceTypes proposal enabled.
+      if (!PConf.hasProposal(Proposal::ReferenceTypes)) {
+        /// Memory index should be 0. Checked in validation phase.
+        auto *MemInst = getMemInstByIdx(StoreMgr, DataSeg->getIdx());
+        /// Check data fits.
+        if (!MemInst->checkAccessBound(Offset, DataSeg->getData().size())) {
+          LOG(ERROR) << ErrCode::DataSegDoesNotFit;
+          LOG(ERROR) << ErrInfo::InfoAST(DataSeg->NodeAttr);
+          return Unexpect(ErrCode::DataSegDoesNotFit);
+        }
       }
     }
 

--- a/lib/interpreter/instantiate/data.cpp
+++ b/lib/interpreter/instantiate/data.cpp
@@ -27,8 +27,10 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       }
       Offset = retrieveValue<uint32_t>(StackMgr.pop());
 
-      /// Check boundary unless ReferenceTypes proposal enabled.
-      if (!PConf.hasProposal(Proposal::ReferenceTypes)) {
+      /// Check boundary unless ReferenceTypes or BulkMemoryOperations proposal
+      /// enabled.
+      if (!PConf.hasProposal(Proposal::ReferenceTypes) &&
+          !PConf.hasProposal(Proposal::BulkMemoryOperations)) {
         /// Memory index should be 0. Checked in validation phase.
         auto *MemInst = getMemInstByIdx(StoreMgr, DataSeg->getIdx());
         /// Check data fits.

--- a/lib/interpreter/instantiate/elem.cpp
+++ b/lib/interpreter/instantiate/elem.cpp
@@ -38,13 +38,16 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       }
       Offset = retrieveValue<uint32_t>(StackMgr.pop());
 
-      /// Table index should be 0. Checked in validation phase.
-      auto *TabInst = getTabInstByIdx(StoreMgr, ElemSeg->getIdx());
-      /// Check elements fits.
-      if (!TabInst->checkAccessBound(Offset, InitVals.size())) {
-        LOG(ERROR) << ErrCode::ElemSegDoesNotFit;
-        LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
-        return Unexpect(ErrCode::ElemSegDoesNotFit);
+      /// Check boundary unless ReferenceTypes proposal enabled.
+      if (!PConf.hasProposal(Proposal::ReferenceTypes)) {
+        /// Table index should be 0. Checked in validation phase.
+        auto *TabInst = getTabInstByIdx(StoreMgr, ElemSeg->getIdx());
+        /// Check elements fits.
+        if (!TabInst->checkAccessBound(Offset, InitVals.size())) {
+          LOG(ERROR) << ErrCode::ElemSegDoesNotFit;
+          LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
+          return Unexpect(ErrCode::ElemSegDoesNotFit);
+        }
       }
     }
 

--- a/lib/interpreter/instantiate/elem.cpp
+++ b/lib/interpreter/instantiate/elem.cpp
@@ -28,9 +28,29 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       InitVals.push_back(StackMgr.pop());
     }
 
+    uint32_t Offset = 0;
+    if (ElemSeg->getMode() == AST::ElementSegment::ElemMode::Active) {
+      /// Run initialize expression.
+      if (auto Res = runExpression(StoreMgr, ElemSeg->getInstrs()); !Res) {
+        LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
+        LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
+        return Unexpect(Res);
+      }
+      Offset = retrieveValue<uint32_t>(StackMgr.pop());
+
+      /// Table index should be 0. Checked in validation phase.
+      auto *TabInst = getTabInstByIdx(StoreMgr, ElemSeg->getIdx());
+      /// Check elements fits.
+      if (!TabInst->checkAccessBound(Offset, InitVals.size())) {
+        LOG(ERROR) << ErrCode::ElemSegDoesNotFit;
+        LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
+        return Unexpect(ErrCode::ElemSegDoesNotFit);
+      }
+    }
+
     /// Make a new element instance.
     auto NewElemInst = std::make_unique<Runtime::Instance::ElementInstance>(
-        ElemSeg->getRefType(), InitVals);
+        Offset, ElemSeg->getRefType(), InitVals);
 
     /// Insert element instance to store manager.
     uint32_t NewElemInstAddr;
@@ -44,11 +64,11 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-/// Initialize table with Element Instances.
+/// Initialize table with Element Instances. See
+/// "include/interpreter/interpreter.h".
 Expect<void> Interpreter::initTable(Runtime::StoreManager &StoreMgr,
                                     Runtime::Instance::ModuleInstance &ModInst,
                                     const AST::ElementSection &ElemSec) {
-  /// A frame with module is pushed into stack outside.
   /// Initialize tables.
   uint32_t Idx = 0;
   for (const auto &ElemSeg : ElemSec.getContent()) {
@@ -56,23 +76,13 @@ Expect<void> Interpreter::initTable(Runtime::StoreManager &StoreMgr,
     if (ElemSeg->getMode() == AST::ElementSegment::ElemMode::Active) {
       /// Table index should be 0. Checked in validation phase.
       auto *TabInst = getTabInstByIdx(StoreMgr, ElemSeg->getIdx());
-
-      /// Run initialize expression.
-      if (auto Res = runExpression(StoreMgr, ElemSeg->getInstrs()); !Res) {
-        LOG(ERROR) << ErrInfo::InfoAST(ASTNodeAttr::Expression);
-        LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
-        return Unexpect(Res);
-      }
-      uint32_t Off = retrieveValue<uint32_t>(StackMgr.pop());
+      const uint32_t Off = ElemInst->getOffset();
 
       /// Replace table[Off : Off + n] with elem[0 : n].
       if (auto Res = TabInst->setRefs(ElemInst->getRefs(), Off, 0,
                                       ElemInst->getRefs().size());
           !Res) {
         LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
-        if (Res.error() == ErrCode::TableOutOfBounds) {
-          return Unexpect(ErrCode::ElemSegDoesNotFit);
-        }
         return Unexpect(Res);
       }
 

--- a/lib/interpreter/instantiate/elem.cpp
+++ b/lib/interpreter/instantiate/elem.cpp
@@ -38,8 +38,10 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       }
       Offset = retrieveValue<uint32_t>(StackMgr.pop());
 
-      /// Check boundary unless ReferenceTypes proposal enabled.
-      if (!PConf.hasProposal(Proposal::ReferenceTypes)) {
+      /// Check boundary unless ReferenceTypes or BulkMemoryOperations proposal
+      /// enabled.
+      if (!PConf.hasProposal(Proposal::ReferenceTypes) &&
+          !PConf.hasProposal(Proposal::BulkMemoryOperations)) {
         /// Table index should be 0. Checked in validation phase.
         auto *TabInst = getTabInstByIdx(StoreMgr, ElemSeg->getIdx());
         /// Check elements fits.

--- a/lib/interpreter/instantiate/elem.cpp
+++ b/lib/interpreter/instantiate/elem.cpp
@@ -70,6 +70,9 @@ Expect<void> Interpreter::initTable(Runtime::StoreManager &StoreMgr,
                                       ElemInst->getRefs().size());
           !Res) {
         LOG(ERROR) << ErrInfo::InfoAST(ElemSeg->NodeAttr);
+        if (Res.error() == ErrCode::TableOutOfBounds) {
+          return Unexpect(ErrCode::ElemSegDoesNotFit);
+        }
         return Unexpect(Res);
       }
 

--- a/lib/interpreter/instantiate/module.cpp
+++ b/lib/interpreter/instantiate/module.cpp
@@ -108,16 +108,6 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     }
   }
 
-  /// Instantiate ElementSection (ElemSec)
-  const AST::ElementSection *ElemSec = Mod.getElementSection();
-  if (ElemSec != nullptr) {
-    if (auto Res = instantiate(StoreMgr, *ModInst, *ElemSec); !Res) {
-      LOG(ERROR) << ErrInfo::InfoAST(ElemSec->NodeAttr);
-      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
-      return Unexpect(Res);
-    }
-  }
-
   /// Pop frame with temp. module.
   StackMgr.popFrame();
 
@@ -137,7 +127,27 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
   /// Push a new frame {ModInst, locals:none}
   StackMgr.pushFrame(ModInst->Addr, 0, 0);
 
-  /// Initialize table with element instances.
+  /// Instantiate ElementSection (ElemSec)
+  const AST::ElementSection *ElemSec = Mod.getElementSection();
+  if (ElemSec != nullptr) {
+    if (auto Res = instantiate(StoreMgr, *ModInst, *ElemSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(ElemSec->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+
+  /// Instantiate DataSection (DataSec)
+  const AST::DataSection *DataSec = Mod.getDataSection();
+  if (DataSec != nullptr) {
+    if (auto Res = instantiate(StoreMgr, *ModInst, *DataSec); !Res) {
+      LOG(ERROR) << ErrInfo::InfoAST(DataSec->NodeAttr);
+      LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+      return Unexpect(Res);
+    }
+  }
+
+  /// initialization table instances
   if (ElemSec != nullptr) {
     if (auto Res = initTable(StoreMgr, *ModInst, *ElemSec); !Res) {
       LOG(ERROR) << ErrInfo::InfoAST(ElemSec->NodeAttr);
@@ -146,10 +156,9 @@ Expect<void> Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     }
   }
 
-  /// Instantiate DataSection and initialization memory instances (DataSec)
-  const AST::DataSection *DataSec = Mod.getDataSection();
+  /// initialization memory instances
   if (DataSec != nullptr) {
-    if (auto Res = instantiate(StoreMgr, *ModInst, *DataSec); !Res) {
+    if (auto Res = initMemory(StoreMgr, *ModInst, *DataSec); !Res) {
       LOG(ERROR) << ErrInfo::InfoAST(DataSec->NodeAttr);
       LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
       return Unexpect(Res);

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -518,6 +518,11 @@ Expect<void> FormChecker::checkInstr(const AST::ParametricInstruction &Instr) {
     return {};
   }
   case OpCode::Select_t: {
+    /// This instruction is for ReferenceTypes proposal.
+    if (!PConf.hasProposal(Proposal::ReferenceTypes)) {
+      LOG(ERROR) << ErrCode::InvalidOpCode;
+      return Unexpect(ErrCode::InvalidOpCode);
+    }
     /// Note: There may be multiple values choise in the future.
     if (Instr.getValTypeList().size() != 1) {
       LOG(ERROR) << ErrCode::InvalidResultArity;

--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -111,6 +111,16 @@ Expect<void> Validator::validate(const AST::Module &Mod) {
     }
   }
 
+  /// In current version, memory must be <= 1, unless reference type proposal.
+  if (!PConf.hasProposal(Proposal::ReferenceTypes) &&
+      Checker.getTables().size() > 1) {
+    LOG(ERROR) << ErrCode::MultiTables;
+    LOG(ERROR) << ErrInfo::InfoInstanceBound(ExternalType::Memory,
+                                             Checker.getMemories().size(), 1);
+    LOG(ERROR) << ErrInfo::InfoAST(Mod.NodeAttr);
+    return Unexpect(ErrCode::MultiTables);
+  }
+
   /// In current version, memory must be <= 1.
   if (Checker.getMemories().size() > 1) {
     LOG(ERROR) << ErrCode::MultiMemories;

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -7,15 +7,17 @@
 namespace SSVM {
 namespace VM {
 
-VM::VM(Configure &InputConfig)
-    : Config(InputConfig), Stage(VMStage::Inited), InterpreterEngine(&Stat),
+VM::VM(const ProposalConfigure &PConf, const Configure &InputConfig)
+    : Config(InputConfig), Stage(VMStage::Inited), LoaderEngine(PConf),
+      ValidatorEngine(PConf), InterpreterEngine(PConf, &Stat),
       Store(std::make_unique<Runtime::StoreManager>()), StoreRef(*Store.get()) {
   initVM();
 }
 
-VM::VM(Configure &InputConfig, Runtime::StoreManager &S)
-    : Config(InputConfig), Stage(VMStage::Inited), InterpreterEngine(&Stat),
-      StoreRef(S) {
+VM::VM(const ProposalConfigure &PConf, const Configure &InputConfig,
+       Runtime::StoreManager &S)
+    : Config(InputConfig), Stage(VMStage::Inited), LoaderEngine(PConf),
+      ValidatorEngine(PConf), InterpreterEngine(PConf, &Stat), StoreRef(S) {
   initVM();
 }
 

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -44,7 +44,8 @@ TEST_P(CoreTest, TestSuites) {
   SSVM::VM::VM VM(PConf, Conf);
   SSVM::SpecTestModule SpecTestMod;
   VM.registerModule(SpecTestMod);
-  auto Compile = [&](const std::string &Filename) -> Expect<std::string> {
+  auto Compile = [&, PConf = std::cref(PConf)](
+                     const std::string &Filename) -> Expect<std::string> {
     SSVM::Loader::Loader Loader(PConf);
     SSVM::Validator::Validator ValidatorEngine(PConf);
     SSVM::AOT::Compiler Compiler;

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -39,14 +39,14 @@ static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
 class CoreTest : public testing::TestWithParam<std::string> {};
 
 TEST_P(CoreTest, TestSuites) {
-  const std::string UnitName = GetParam();
+  const auto [Proposal, PConf, UnitName] = T.resolve(GetParam());
   SSVM::VM::Configure Conf;
-  SSVM::VM::VM VM(Conf);
+  SSVM::VM::VM VM(PConf, Conf);
   SSVM::SpecTestModule SpecTestMod;
   VM.registerModule(SpecTestMod);
   auto Compile = [&](const std::string &Filename) -> Expect<std::string> {
-    SSVM::Loader::Loader Loader;
-    SSVM::Validator::Validator ValidatorEngine;
+    SSVM::Loader::Loader Loader(PConf);
+    SSVM::Validator::Validator ValidatorEngine(PConf);
     SSVM::AOT::Compiler Compiler;
     Compiler.setOptimizationLevel(SSVM::AOT::Compiler::OptimizationLevel::O0);
     Compiler.setDumpIR(true);
@@ -214,7 +214,7 @@ TEST_P(CoreTest, TestSuites) {
     return true;
   };
 
-  T.run(UnitName);
+  T.run(Proposal, UnitName);
 }
 
 /// Initiate test suite.

--- a/test/aot/AOTwagonTest.cpp
+++ b/test/aot/AOTwagonTest.cpp
@@ -34,7 +34,8 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-SSVM::Loader::Loader Loader;
+SSVM::ProposalConfigure ProposalConf;
+SSVM::Loader::Loader Loader(ProposalConf);
 
 TEST(WagonTest, Load__add_ex_main) { BODY("add-ex-main"); }
 TEST(WagonTest, Load__add_ex) { BODY("add-ex"); }

--- a/test/externref/ExternrefTest.cpp
+++ b/test/externref/ExternrefTest.cpp
@@ -15,8 +15,9 @@
 namespace {
 
 TEST(ExternRefTest, Ref__Functions) {
+  SSVM::ProposalConfigure PConf(SSVM::Proposal::ReferenceTypes);
   SSVM::VM::Configure Conf;
-  SSVM::VM::VM VM(Conf);
+  SSVM::VM::VM VM(PConf, Conf);
   SSVM::ExternMod ExtMod;
   std::vector<SSVM::ValVariant> FuncArgs;
   VM.registerModule(ExtMod);
@@ -59,8 +60,9 @@ TEST(ExternRefTest, Ref__Functions) {
 }
 
 TEST(ExternRefTest, Ref__STL) {
+  SSVM::ProposalConfigure PConf(SSVM::Proposal::ReferenceTypes);
   SSVM::VM::Configure Conf;
-  SSVM::VM::VM VM(Conf);
+  SSVM::VM::VM VM(PConf, Conf);
   SSVM::ExternMod ExtMod;
   std::vector<SSVM::ValVariant> FuncArgs;
   VM.registerModule(ExtMod);

--- a/test/interpreter/InterpreterTest.cpp
+++ b/test/interpreter/InterpreterTest.cpp
@@ -37,9 +37,9 @@ static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
 class CoreTest : public testing::TestWithParam<std::string> {};
 
 TEST_P(CoreTest, TestSuites) {
-  const std::string UnitName = GetParam();
+  const auto [Proposal, PConf, UnitName] = T.resolve(GetParam());
   SSVM::VM::Configure Conf;
-  SSVM::VM::VM VM(Conf);
+  SSVM::VM::VM VM(PConf, Conf);
   SSVM::SpecTestModule SpecTestMod;
   VM.registerModule(SpecTestMod);
   T.onModule = [&VM](const std::string &ModName,
@@ -182,7 +182,7 @@ TEST_P(CoreTest, TestSuites) {
     return true;
   };
 
-  T.run(UnitName);
+  T.run(Proposal, UnitName);
 }
 
 /// Initiate test suite.

--- a/test/spec/CMakeLists.txt
+++ b/test/spec/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   ssvm_unit_test
   GIT_REPOSITORY https://github.com/second-state/ssvm-unittest.git
-  GIT_TAG wasm-ref-types
+  GIT_TAG wasm-core
 )
 
 FetchContent_GetProperties(ssvm_unit_test)
@@ -13,8 +13,18 @@ if (NOT ssvm_unit_test_POPULATED)
 endif ()
 
 configure_files(
-  ${ssvm_unit_test_SOURCE_DIR}/core
-  ${CMAKE_CURRENT_BINARY_DIR}/testSuites
+  ${ssvm_unit_test_SOURCE_DIR}/core/
+  ${CMAKE_CURRENT_BINARY_DIR}/testSuites/core/
+  COPYONLY
+)
+configure_files(
+  ${ssvm_unit_test_SOURCE_DIR}/reference-types/
+  ${CMAKE_CURRENT_BINARY_DIR}/testSuites/reference-types/
+  COPYONLY
+)
+configure_files(
+  ${ssvm_unit_test_SOURCE_DIR}/bulk-memory-operations/
+  ${CMAKE_CURRENT_BINARY_DIR}/testSuites/bulk-memory-operations/
   COPYONLY
 )
 

--- a/test/spec/spectest.h
+++ b/test/spec/spectest.h
@@ -16,6 +16,7 @@
 
 #include "common/errcode.h"
 #include "common/filesystem.h"
+#include "common/proposal.h"
 #include "runtime/hostfunc.h"
 #include "runtime/importobj.h"
 #include "runtime/instance/memory.h"
@@ -120,9 +121,11 @@ public:
   explicit SpecTest(std::filesystem::path Root)
       : TestsuiteRoot(std::move(Root)) {}
 
-  std::vector<std::string> enumerate();
+  std::vector<std::string> enumerate() const;
+  std::tuple<std::string_view, SSVM::ProposalConfigure, std::string>
+  resolve(std::string_view Params) const;
 
-  void run(std::string UnitName);
+  void run(std::string_view Proposal, std::string_view UnitName);
 
   using ModuleCallback = Expect<void>(const std::string &Modname,
                                       const std::string &Filename);

--- a/tools/ssvm/main.cpp
+++ b/tools/ssvm/main.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "common/filesystem.h"
+#include "common/proposal.h"
 #include "common/value.h"
 #include "host/wasi/wasimodule.h"
 #include "po/argument_parser.h"
@@ -37,21 +38,43 @@ int main(int Argc, const char *Argv[]) {
           "Environ variables. Each variables can specified as --env `NAME=VALUE`."s),
       PO::MetaVar("ENVS"s));
 
+  PO::Option<PO::Toggle> BulkMemoryOperations(
+      PO::Description("Enable Bulk-memory operations"));
+  PO::Option<PO::Toggle> ReferenceTypes(
+      PO::Description("Enable Reference types (externref)"));
+  PO::Option<PO::Toggle> All(PO::Description("Enable all features"));
+
   if (!PO::ArgumentParser()
            .add_option(WasmName)
            .add_option(Args)
            .add_option("reactor", Reactor)
            .add_option("dir", Dir)
            .add_option("env", Env)
+           .add_option("enable-bulk-memory", BulkMemoryOperations)
+           .add_option("enable-reference-types", ReferenceTypes)
+           .add_option("enable-all", All)
            .parse(Argc, Argv)) {
     return 0;
+  }
+
+  SSVM::ProposalConfigure ProposalConf;
+  if (BulkMemoryOperations.value()) {
+    ProposalConf.addProposal(SSVM::Proposal::BulkMemoryOperations);
+  }
+  if (ReferenceTypes.value()) {
+    ProposalConf.addProposal(SSVM::Proposal::ReferenceTypes);
+  }
+  if (All.value()) {
+    ProposalConf.addProposal(SSVM::Proposal::BulkMemoryOperations);
+    ProposalConf.addProposal(SSVM::Proposal::ReferenceTypes);
   }
 
   std::string InputPath = std::filesystem::absolute(WasmName.value()).string();
   SSVM::VM::Configure Conf;
   Conf.addVMType(SSVM::VM::Configure::VMType::Wasi);
   Conf.addVMType(SSVM::VM::Configure::VMType::SSVM_Process);
-  SSVM::VM::VM VM(Conf);
+
+  SSVM::VM::VM VM(ProposalConf, Conf);
 
   SSVM::Host::WasiModule *WasiMod = dynamic_cast<SSVM::Host::WasiModule *>(
       VM.getImportModule(SSVM::VM::Configure::VMType::Wasi));


### PR DESCRIPTION
### Adjust testsuite directory hierarchy
### Fix core testcase errors
* Fix edge case for signed trunc from f64 to i32* Add Multitable error code
* Check length of data segments and element segments before writing into table and memory
### Fix reference-types testcase errors
* Check DataSeg and ElemSeg fit only if reference-types is disabled
* Generate error on instructions introduced by proposals
* Verbose error message on AOT execution error
### Disable instructions from proposal
* Add error messages for these instructions
### Remove useless `extern "C"` on roundeve