### PR TITLE
Memory page limitations

### DIFF
--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -71,11 +71,16 @@ public:
     return Hosts.test(static_cast<uint8_t>(Host));
   }
 
+  void setMaxMemoryPage(const uint32_t Page) noexcept { MaxMemPage = Page; }
+
+  uint32_t getMaxMemoryPage() const noexcept { return MaxMemPage; }
+
 private:
   void addSet(const Proposal P) noexcept { addProposal(P); }
   void addSet(const HostRegistration H) noexcept { addHostRegistration(H); }
   std::bitset<static_cast<uint8_t>(Proposal::Max)> Proposals;
   std::bitset<static_cast<uint8_t>(HostRegistration::Max)> Hosts;
+  uint32_t MaxMemPage = 65536;
 };
 
 } // namespace SSVM

--- a/include/runtime/instance/type.h
+++ b/include/runtime/instance/type.h
@@ -41,8 +41,6 @@ struct FType {
 
   /// Getter of symbol
   const auto &getSymbol() const noexcept { return Symbol; }
-  /// Setter of symbol
-  void setSymbol(Loader::Symbol<Wrapper> S) { Symbol = std::move(S); }
 
   std::vector<ValType> Params;
   std::vector<ValType> Returns;

--- a/include/runtime/storemgr.h
+++ b/include/runtime/storemgr.h
@@ -55,27 +55,33 @@ public:
   ~StoreManager() = default;
 
   /// Import instances and move owner to store manager.
-  uint32_t importModule(std::unique_ptr<Instance::ModuleInstance> Mod) {
-    Mod->Addr = ModInsts.size();
-    return importInstance(std::move(Mod), ImpModInsts, ModInsts);
+  template <typename... Args> uint32_t importModule(Args &&... Values) {
+    uint32_t ModAddr =
+        importInstance(ImpModInsts, ModInsts, std::forward<Args>(Values)...);
+    ModInsts.back()->Addr = ModAddr;
+    return ModAddr;
   }
-  uint32_t importFunction(std::unique_ptr<Instance::FunctionInstance> Func) {
-    return importInstance(std::move(Func), ImpFuncInsts, FuncInsts);
+  template <typename... Args> uint32_t importFunction(Args &&... Values) {
+    return importInstance(ImpFuncInsts, FuncInsts,
+                          std::forward<Args>(Values)...);
   }
-  uint32_t importTable(std::unique_ptr<Instance::TableInstance> Tab) {
-    return importInstance(std::move(Tab), ImpTabInsts, TabInsts);
+  template <typename... Args> uint32_t importTable(Args &&... Values) {
+    return importInstance(ImpTabInsts, TabInsts, std::forward<Args>(Values)...);
   }
-  uint32_t importMemory(std::unique_ptr<Instance::MemoryInstance> Mem) {
-    return importInstance(std::move(Mem), ImpMemInsts, MemInsts);
+  template <typename... Args> uint32_t importMemory(Args &&... Values) {
+    return importInstance(ImpMemInsts, MemInsts, std::forward<Args>(Values)...);
   }
-  uint32_t importGlobal(std::unique_ptr<Instance::GlobalInstance> Glob) {
-    return importInstance(std::move(Glob), ImpGlobInsts, GlobInsts);
+  template <typename... Args> uint32_t importGlobal(Args &&... Values) {
+    return importInstance(ImpGlobInsts, GlobInsts,
+                          std::forward<Args>(Values)...);
   }
-  uint32_t importElement(std::unique_ptr<Instance::ElementInstance> Elem) {
-    return importInstance(std::move(Elem), ImpElemInsts, ElemInsts);
+  template <typename... Args> uint32_t importElement(Args &&... Values) {
+    return importInstance(ImpElemInsts, ElemInsts,
+                          std::forward<Args>(Values)...);
   }
-  uint32_t importData(std::unique_ptr<Instance::DataInstance> Data) {
-    return importInstance(std::move(Data), ImpDataInsts, DataInsts);
+  template <typename... Args> uint32_t importData(Args &&... Values) {
+    return importInstance(ImpDataInsts, DataInsts,
+                          std::forward<Args>(Values)...);
   }
 
   /// Import host instances but not move ownership.
@@ -93,34 +99,40 @@ public:
   }
 
   /// Insert instances for instantiation and move ownership to store manager.
-  uint32_t pushModule(std::unique_ptr<Instance::ModuleInstance> Mod) {
+  template <typename... Args> uint32_t pushModule(Args &&... Values) {
     ++NumMod;
-    Mod->Addr = ModInsts.size();
-    return importInstance(std::move(Mod), ImpModInsts, ModInsts);
+    uint32_t ModAddr =
+        importInstance(ImpModInsts, ModInsts, std::forward<Args>(Values)...);
+    ModInsts.back()->Addr = ModAddr;
+    return ModAddr;
   }
-  uint32_t pushFunction(std::unique_ptr<Instance::FunctionInstance> Func) {
+  template <typename... Args> uint32_t pushFunction(Args &&... Values) {
     ++NumFunc;
-    return importInstance(std::move(Func), ImpFuncInsts, FuncInsts);
+    return importInstance(ImpFuncInsts, FuncInsts,
+                          std::forward<Args>(Values)...);
   }
-  uint32_t pushTable(std::unique_ptr<Instance::TableInstance> Tab) {
+  template <typename... Args> uint32_t pushTable(Args &&... Values) {
     ++NumTab;
-    return importInstance(std::move(Tab), ImpTabInsts, TabInsts);
+    return importInstance(ImpTabInsts, TabInsts, std::forward<Args>(Values)...);
   }
-  uint32_t pushMemory(std::unique_ptr<Instance::MemoryInstance> Mem) {
+  template <typename... Args> uint32_t pushMemory(Args &&... Values) {
     ++NumMem;
-    return importInstance(std::move(Mem), ImpMemInsts, MemInsts);
+    return importInstance(ImpMemInsts, MemInsts, std::forward<Args>(Values)...);
   }
-  uint32_t pushGlobal(std::unique_ptr<Instance::GlobalInstance> Glob) {
+  template <typename... Args> uint32_t pushGlobal(Args &&... Values) {
     ++NumGlob;
-    return importInstance(std::move(Glob), ImpGlobInsts, GlobInsts);
+    return importInstance(ImpGlobInsts, GlobInsts,
+                          std::forward<Args>(Values)...);
   }
-  uint32_t pushElement(std::unique_ptr<Instance::ElementInstance> Elem) {
+  template <typename... Args> uint32_t pushElement(Args &&... Values) {
     ++NumElem;
-    return importInstance(std::move(Elem), ImpElemInsts, ElemInsts);
+    return importInstance(ImpElemInsts, ElemInsts,
+                          std::forward<Args>(Values)...);
   }
-  uint32_t pushData(std::unique_ptr<Instance::DataInstance> Data) {
+  template <typename... Args> uint32_t pushData(Args &&... Values) {
     ++NumData;
-    return importInstance(std::move(Data), ImpDataInsts, DataInsts);
+    return importInstance(ImpDataInsts, DataInsts,
+                          std::forward<Args>(Values)...);
   }
 
   /// Pop temp. module. Dangerous function for used when instantiating only.
@@ -266,14 +278,13 @@ public:
 
 private:
   /// Helper function for importing instances and move ownership.
-  template <typename T>
+  template <typename T, typename... Args>
   std::enable_if_t<IsInstanceV<T>, uint32_t>
-  importInstance(std::unique_ptr<T> Inst,
-                 std::vector<std::unique_ptr<T>> &ImpInstsVec,
-                 std::vector<T *> &InstsVec) {
+  importInstance(std::vector<std::unique_ptr<T>> &ImpInstsVec,
+                 std::vector<T *> &InstsVec, Args &&... Values) {
     uint32_t Addr = InstsVec.size();
-    InstsVec.push_back(Inst.get());
-    ImpInstsVec.push_back(std::move(Inst));
+    ImpInstsVec.push_back(std::make_unique<T>(std::forward<Args>(Values)...));
+    InstsVec.push_back(ImpInstsVec.back().get());
     return Addr;
   }
 

--- a/lib/interpreter/helper.cpp
+++ b/lib/interpreter/helper.cpp
@@ -62,7 +62,7 @@ Interpreter::enterFunction(Runtime::StoreManager &StoreMgr,
     }
     /// For host function case, the continuation will be the next.
     return From + 1;
-  } else if (auto CompiledFunc = Func.getSymbol()) {
+  } else if (Func.isCompiledFunction()) {
     auto Wrapper = Func.getFuncType().getSymbol();
     /// Compiled function case: Push frame with locals and args.
     const size_t ArgsN = FuncType.Params.size();
@@ -89,7 +89,8 @@ Interpreter::enterFunction(Runtime::StoreManager &StoreMgr,
     const int Status = sigsetjmp(*TrapJump, true);
     if (Status == 0) {
       SignalEnabler Enabler;
-      Wrapper(&ExecutionContext, CompiledFunc.get(), Args.data(), Rets.data());
+      Wrapper(&ExecutionContext, Func.getSymbol().get(), Args.data(),
+              Rets.data());
     }
 
     TrapJump = std::move(OldTrapJump);

--- a/lib/interpreter/instantiate/data.cpp
+++ b/lib/interpreter/instantiate/data.cpp
@@ -42,16 +42,12 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       }
     }
 
-    /// Make a new data instance.
-    auto NewDataInst = std::make_unique<Runtime::Instance::DataInstance>(
-        Offset, DataSeg.getData());
-
     /// Insert data instance to store manager.
     uint32_t NewDataInstAddr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewDataInstAddr = StoreMgr.pushData(std::move(NewDataInst));
+      NewDataInstAddr = StoreMgr.pushData(Offset, DataSeg.getData());
     } else {
-      NewDataInstAddr = StoreMgr.importData(std::move(NewDataInst));
+      NewDataInstAddr = StoreMgr.importData(Offset, DataSeg.getData());
     }
     ModInst.addDataAddr(NewDataInstAddr);
   }

--- a/lib/interpreter/instantiate/elem.cpp
+++ b/lib/interpreter/instantiate/elem.cpp
@@ -53,16 +53,14 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       }
     }
 
-    /// Make a new element instance.
-    auto NewElemInst = std::make_unique<Runtime::Instance::ElementInstance>(
-        Offset, ElemSeg.getRefType(), InitVals);
-
     /// Insert element instance to store manager.
     uint32_t NewElemInstAddr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewElemInstAddr = StoreMgr.pushElement(std::move(NewElemInst));
+      NewElemInstAddr =
+          StoreMgr.pushElement(Offset, ElemSeg.getRefType(), InitVals);
     } else {
-      NewElemInstAddr = StoreMgr.importElement(std::move(NewElemInst));
+      NewElemInstAddr =
+          StoreMgr.importElement(Offset, ElemSeg.getRefType(), InitVals);
     }
     ModInst.addElemAddr(NewElemInstAddr);
   }

--- a/lib/interpreter/instantiate/memory.cpp
+++ b/lib/interpreter/instantiate/memory.cpp
@@ -14,16 +14,12 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
                          const AST::MemorySection &MemSec) {
   /// Iterate and istantiate memory types.
   for (const auto &MemType : MemSec.getContent()) {
-    /// Make a new memory instance.
-    auto NewMemInst =
-        std::make_unique<Runtime::Instance::MemoryInstance>(MemType.getLimit());
-
     /// Insert memory instance to store manager.
     uint32_t NewMemInstAddr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewMemInstAddr = StoreMgr.pushMemory(std::move(NewMemInst));
+      NewMemInstAddr = StoreMgr.pushMemory(MemType.getLimit());
     } else {
-      NewMemInstAddr = StoreMgr.importMemory(std::move(NewMemInst));
+      NewMemInstAddr = StoreMgr.importMemory(MemType.getLimit());
     }
     ModInst.addMemAddr(NewMemInstAddr);
   }

--- a/lib/interpreter/instantiate/memory.cpp
+++ b/lib/interpreter/instantiate/memory.cpp
@@ -17,9 +17,11 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     /// Insert memory instance to store manager.
     uint32_t NewMemInstAddr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewMemInstAddr = StoreMgr.pushMemory(MemType.getLimit());
+      NewMemInstAddr =
+          StoreMgr.pushMemory(MemType.getLimit(), Conf.getMaxMemoryPage());
     } else {
-      NewMemInstAddr = StoreMgr.importMemory(MemType.getLimit());
+      NewMemInstAddr =
+          StoreMgr.importMemory(MemType.getLimit(), Conf.getMaxMemoryPage());
     }
     ModInst.addMemAddr(NewMemInstAddr);
   }

--- a/lib/interpreter/instantiate/table.cpp
+++ b/lib/interpreter/instantiate/table.cpp
@@ -14,16 +14,14 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
                          const AST::TableSection &TabSec) {
   /// Iterate and instantiate table types.
   for (const auto &TabType : TabSec.getContent()) {
-    /// Make a new table instance.
-    auto NewTabInst = std::make_unique<Runtime::Instance::TableInstance>(
-        TabType.getReferenceType(), TabType.getLimit());
-
     /// Insert table instance to store manager.
     uint32_t NewTabInstAddr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewTabInstAddr = StoreMgr.pushTable(std::move(NewTabInst));
+      NewTabInstAddr =
+          StoreMgr.pushTable(TabType.getReferenceType(), TabType.getLimit());
     } else {
-      NewTabInstAddr = StoreMgr.importTable(std::move(NewTabInst));
+      NewTabInstAddr =
+          StoreMgr.importTable(TabType.getReferenceType(), TabType.getLimit());
     }
     ModInst.addTableAddr(NewTabInstAddr);
   }

--- a/lib/interpreter/interpreter.cpp
+++ b/lib/interpreter/interpreter.cpp
@@ -32,13 +32,10 @@ Expect<void> Interpreter::registerModule(Runtime::StoreManager &StoreMgr,
     LOG(ERROR) << ErrInfo::InfoRegistering(Obj.getModuleName());
     return Unexpect(ErrCode::ModuleNameConflict);
   }
-  auto NewModInst =
-      std::make_unique<Runtime::Instance::ModuleInstance>(Obj.getModuleName());
-  auto ModInstAddr = StoreMgr.importModule(std::move(NewModInst));
+  auto ModInstAddr = StoreMgr.importModule(Obj.getModuleName());
   auto *ModInst = *StoreMgr.getModule(ModInstAddr);
 
   for (auto &Func : Obj.getFuncs()) {
-    Func.second->setModuleAddr(ModInstAddr);
     uint32_t Addr = StoreMgr.importHostFunction(*Func.second.get());
     ModInst->addFuncAddr(Addr);
     ModInst->exportFunction(Func.first, ModInst->getFuncNum() - 1);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(externref)
 add_subdirectory(expected)
 add_subdirectory(span)
 add_subdirectory(po)
+add_subdirectory(memlimit)
 
 if(BUILD_COVERAGE)
   setup_target_for_coverage_gcovr_html(

--- a/test/memlimit/CMakeLists.txt
+++ b/test/memlimit/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_executable(ssvmMemLimitTests
+  MemLimitTest.cpp
+)
+
+add_test(ssvmMemLimitTests ssvmMemLimitTests)
+
+target_link_libraries(ssvmMemLimitTests
+  PRIVATE
+  utilGoogleTest
+  ssvmVM
+)

--- a/test/memlimit/MemLimitTest.cpp
+++ b/test/memlimit/MemLimitTest.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "common/configure.h"
+#include "runtime/instance/memory.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(MemLimitTest, Limit__Pages) {
+  using MemInst = SSVM::Runtime::Instance::MemoryInstance;
+  SSVM::Configure Conf;
+  Conf.setMaxMemoryPage(256);
+
+  SSVM::AST::Limit Lim1(257);
+  MemInst Inst1(Lim1, Conf.getMaxMemoryPage());
+  ASSERT_TRUE(Inst1.getDataPtr() == nullptr);
+
+  MemInst Inst2(Lim1);
+  ASSERT_FALSE(Inst2.getDataPtr() == nullptr);
+
+  SSVM::AST::Limit Lim2(1);
+  MemInst Inst3(Lim2, Conf.getMaxMemoryPage());
+  ASSERT_FALSE(Inst3.getDataPtr() == nullptr);
+  ASSERT_FALSE(Inst3.growPage(256));
+  ASSERT_TRUE(Inst3.growPage(255));
+
+  MemInst Inst4(Lim2);
+  ASSERT_FALSE(Inst4.getDataPtr() == nullptr);
+  ASSERT_TRUE(Inst4.growPage(256));
+
+  SSVM::AST::Limit Lim3(1, 128);
+  MemInst Inst5(Lim3, Conf.getMaxMemoryPage());
+  ASSERT_FALSE(Inst5.getDataPtr() == nullptr);
+  ASSERT_FALSE(Inst5.growPage(128));
+  ASSERT_TRUE(Inst5.growPage(127));
+}
+
+} // namespace
+
+GTEST_API_ int main(int argc, char **argv) {
+  SSVM::Log::setErrorLoggingLevel();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tools/ssvm/ssvmr.cpp
+++ b/tools/ssvm/ssvmr.cpp
@@ -46,6 +46,11 @@ int main(int Argc, const char *Argv[]) {
   PO::Option<PO::Toggle> SIMD(PO::Description("Enable SIMD"sv));
   PO::Option<PO::Toggle> All(PO::Description("Enable all features"sv));
 
+  PO::List<int> MemLim(
+      PO::Description(
+          "Limitation of pages(as size of 64 KiB) in every memory instance. Upper bound can be specified as --memory-page-limit `PAGE_COUNT`."sv),
+      PO::MetaVar("PAGE_COUNT"sv));
+
   PO::List<std::string> AllowCmd(
       PO::Description(
           "Allow commands called from ssvm_process host functions. Each command can be specified as --allow-command `COMMAND`."sv),
@@ -63,6 +68,7 @@ int main(int Argc, const char *Argv[]) {
            .add_option("enable-reference-types"sv, ReferenceTypes)
            .add_option("enable-simd"sv, SIMD)
            .add_option("enable-all"sv, All)
+           .add_option("memory-page-limit"sv, MemLim)
            .add_option("allow-command"sv, AllowCmd)
            .add_option("allow-command-all"sv, AllowCmdAll)
            .parse(Argc, Argv)) {
@@ -87,6 +93,9 @@ int main(int Argc, const char *Argv[]) {
     Conf.addProposal(SSVM::Proposal::BulkMemoryOperations);
     Conf.addProposal(SSVM::Proposal::ReferenceTypes);
     Conf.addProposal(SSVM::Proposal::SIMD);
+  }
+  if (MemLim.value().size() > 0) {
+    Conf.setMaxMemoryPage(MemLim.value().back());
   }
 
   Conf.addHostRegistration(SSVM::HostRegistration::Wasi);


### PR DESCRIPTION
1. Refactor function instance for saving spaces.
2. Use template in store manager to saving move operations.
3. Add memory page count limitations in configuration and tool.