### PR TITLE
Refactor for SSVM C API.

### DIFF
--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -35,7 +35,7 @@ enum class Proposal : uint8_t {
 };
 
 /// Host Module Registration enum class.
-enum class HostRegistration : uint8_t { Wasi, SSVM_Process, Max };
+enum class HostRegistration : uint8_t { Wasi = 0, SSVM_Process, Max };
 
 /// Proposal name enumeration string mapping.
 extern const std::unordered_map<Proposal, std::string_view> ProposalStr;

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -18,6 +18,8 @@ namespace Log {
 
 void passEasyloggingppArgs(int Argc, char *Argv[]);
 
+void setDebugLoggingLevel();
+
 void setErrorLoggingLevel();
 
 extern el::base::type::StoragePointer elStorage;

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -540,7 +540,7 @@ private:
   /// Instantiation mode enumeration class
   enum class InstantiateMode : uint8_t { Instantiate = 0, ImportWasm };
   /// SSVM configuration
-  const Configure &Conf;
+  const Configure Conf;
   /// Instantiation mode
   InstantiateMode InsMode;
   /// Stack

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -95,10 +95,9 @@ public:
   }
   ~Interpreter() noexcept { This = nullptr; }
 
-  /// Instantiate Wasm Module.
+  /// Instantiate Wasm Module as the anonymous active module.
   Expect<void> instantiateModule(Runtime::StoreManager &StoreMgr,
-                                 const AST::Module &Mod,
-                                 std::string_view Name = {});
+                                 const AST::Module &Mod);
 
   /// Register host module.
   Expect<void> registerModule(Runtime::StoreManager &StoreMgr,

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -40,7 +40,7 @@ public:
   Expect<std::unique_ptr<AST::Module>> parseModule(Span<const uint8_t> Code);
 
 private:
-  const Configure &Conf;
+  const Configure Conf;
   FileMgrFStream FSMgr;
   FileMgrVector FVMgr;
   LDMgr LMgr;

--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -158,7 +158,8 @@ public:
   }
 
   /// Get slice of Data[Offset : Offset + Length - 1]
-  Expect<Span<Byte>> getBytes(const uint32_t Offset, const uint32_t Length) {
+  Expect<Span<Byte>> getBytes(const uint32_t Offset,
+                              const uint32_t Length) const noexcept {
     /// Check memory boundary.
     if (!checkAccessBound(Offset, Length)) {
       LOG(ERROR) << ErrCode::MemoryOutOfBounds;
@@ -212,7 +213,8 @@ public:
 
   /// Get an uint8 array from Data[Offset : Offset + Length - 1]
   Expect<void> getArray(uint8_t *Arr, const uint32_t Offset,
-                        const uint32_t Length, const bool IsReverse = false) {
+                        const uint32_t Length,
+                        const bool IsReverse = false) const noexcept {
     /// Check memory boundary.
     if (!checkAccessBound(Offset, Length)) {
       LOG(ERROR) << ErrCode::MemoryOutOfBounds;
@@ -286,7 +288,8 @@ public:
   /// \returns void when success, ErrCode when failed.
   template <typename T>
   typename std::enable_if_t<IsWasmNumV<T>, Expect<void>>
-  loadValue(T &Value, const uint32_t Offset, const uint32_t Length) {
+  loadValue(T &Value, const uint32_t Offset,
+            const uint32_t Length) const noexcept {
     /// Check data boundary.
     if (Length > sizeof(T)) {
       LOG(ERROR) << ErrCode::MemoryOutOfBounds;

--- a/include/runtime/instance/table.h
+++ b/include/runtime/instance/table.h
@@ -74,6 +74,9 @@ public:
     std::fill_n(Refs.end() - Count, Count, Val);
     return true;
   }
+  bool growTable(const uint32_t Count) {
+    return growTable(Count, genNullRef(Type));
+  }
 
   /// Get slice of Refs[Offset : Offset + Length - 1]
   Expect<Span<const RefVariant>> getRefs(const uint32_t Offset,

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -67,7 +67,7 @@ private:
 
   static inline const uint32_t LIMIT_MEMORYTYPE = 1U << 16;
   /// Proposal configure
-  const Configure &Conf;
+  const Configure Conf;
   /// Formal checker
   FormChecker Checker;
 };

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -45,6 +45,7 @@ public:
   Expect<void> registerModule(std::string_view Name,
                               const std::filesystem::path &Path);
   Expect<void> registerModule(std::string_view Name, Span<const Byte> Code);
+  Expect<void> registerModule(std::string_view Name, const AST::Module &Module);
   Expect<void> registerModule(const Runtime::ImportObject &Obj);
 
   /// Rapidly load, validate, instantiate, and run wasm function.
@@ -54,10 +55,14 @@ public:
   Expect<std::vector<ValVariant>>
   runWasmFile(Span<const Byte> Code, std::string_view Func,
               Span<const ValVariant> Params = {});
+  Expect<std::vector<ValVariant>>
+  runWasmFile(const AST::Module &Module, std::string_view Func,
+              Span<const ValVariant> Params = {});
 
-  /// Load given wasm file or wasm bytecode.
+  /// Load given wasm file, wasm bytecode, or wasm module.
   Expect<void> loadWasm(const std::filesystem::path &Path);
   Expect<void> loadWasm(Span<const Byte> Code);
+  Expect<void> loadWasm(const AST::Module &Module);
 
   /// ======= Functions can be called after loaded stage. =======
   /// Validate loaded wasm module.
@@ -98,10 +103,6 @@ private:
   enum class VMStage : uint8_t { Inited, Loaded, Validated, Instantiated };
 
   void initVM();
-  Expect<void> registerModule(std::string_view Name, const AST::Module &Module);
-  Expect<std::vector<ValVariant>> runWasmFile(const AST::Module &Module,
-                                              std::string_view Func,
-                                              Span<const ValVariant> Params);
 
   /// VM environment.
   const Configure &Config;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -105,7 +105,7 @@ private:
   void initVM();
 
   /// VM environment.
-  const Configure &Config;
+  const Configure Conf;
   Statistics::Statistics Stat;
   VMStage Stage;
 

--- a/lib/common/log.cpp
+++ b/lib/common/log.cpp
@@ -13,6 +13,12 @@ void passEasyloggingppArgs(int Argc, char *Argv[]) {
   START_EASYLOGGINGPP(Argc, Argv);
 }
 
+void setDebugLoggingLevel() {
+  el::Loggers::addFlag(el::LoggingFlag::HierarchicalLogging);
+  el::Loggers::addFlag(el::LoggingFlag::IgnoreSigInt);
+  el::Loggers::setLoggingLevel(el::Level::Debug);
+}
+
 void setErrorLoggingLevel() {
   el::Loggers::addFlag(el::LoggingFlag::HierarchicalLogging);
   el::Loggers::addFlag(el::LoggingFlag::IgnoreSigInt);

--- a/lib/interpreter/interpreter.cpp
+++ b/lib/interpreter/interpreter.cpp
@@ -10,13 +10,9 @@ namespace Interpreter {
 
 /// Instantiate Wasm Module. See "include/interpreter/interpreter.h".
 Expect<void> Interpreter::instantiateModule(Runtime::StoreManager &StoreMgr,
-                                            const AST::Module &Mod,
-                                            std::string_view Name) {
+                                            const AST::Module &Mod) {
   InsMode = InstantiateMode::Instantiate;
-  if (auto Res = instantiate(StoreMgr, Mod, Name); !Res) {
-    if (Name != "") {
-      LOG(ERROR) << ErrInfo::InfoRegistering(Name);
-    }
+  if (auto Res = instantiate(StoreMgr, Mod, ""); !Res) {
     return Unexpect(Res);
   }
   return {};

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -196,8 +196,7 @@ Expect<void> VM::instantiate() {
     LOG(ERROR) << ErrCode::WrongVMWorkflow;
     return Unexpect(ErrCode::WrongVMWorkflow);
   }
-  if (auto Res =
-          InterpreterEngine.instantiateModule(StoreRef, *Mod.get(), "")) {
+  if (auto Res = InterpreterEngine.instantiateModule(StoreRef, *Mod.get())) {
     Stage = VMStage::Instantiated;
     return {};
   } else {
@@ -209,15 +208,15 @@ Expect<std::vector<ValVariant>> VM::execute(std::string_view Func,
                                             Span<const ValVariant> Params) {
   /// Check exports for finding function address.
   const auto FuncExp = StoreRef.getFuncExports();
-  if (FuncExp.find(Func) == FuncExp.cend()) {
+  const auto FuncIter = FuncExp.find(Func);
+  if (FuncIter == FuncExp.cend()) {
     LOG(ERROR) << ErrCode::FuncNotFound;
     LOG(ERROR) << ErrInfo::InfoExecuting("", Func);
     return Unexpect(ErrCode::FuncNotFound);
   }
 
   /// Execute function.
-  if (auto Res = InterpreterEngine.invoke(StoreRef, FuncExp.find(Func)->second,
-                                          Params)) {
+  if (auto Res = InterpreterEngine.invoke(StoreRef, FuncIter->second, Params)) {
     return Res;
   } else {
     LOG(ERROR) << ErrInfo::InfoExecuting("", Func);
@@ -240,7 +239,7 @@ Expect<std::vector<ValVariant>> VM::execute(std::string_view Mod,
 
   /// Get exports and find function.
   const auto FuncExp = ModInst->getFuncExports();
-  auto FuncIter = FuncExp.find(Func);
+  const auto FuncIter = FuncExp.find(Func);
   if (FuncIter == FuncExp.cend()) {
     LOG(ERROR) << ErrCode::FuncNotFound;
     LOG(ERROR) << ErrInfo::InfoExecuting(Mod, Func);

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -8,27 +8,27 @@ namespace SSVM {
 namespace VM {
 
 VM::VM(const Configure &Conf)
-    : Config(Conf), Stage(VMStage::Inited), LoaderEngine(Conf),
+    : Conf(Conf), Stage(VMStage::Inited), LoaderEngine(Conf),
       ValidatorEngine(Conf), InterpreterEngine(Conf, &Stat),
       Store(std::make_unique<Runtime::StoreManager>()), StoreRef(*Store.get()) {
   initVM();
 }
 
 VM::VM(const Configure &Conf, Runtime::StoreManager &S)
-    : Config(Conf), Stage(VMStage::Inited), LoaderEngine(Conf),
+    : Conf(Conf), Stage(VMStage::Inited), LoaderEngine(Conf),
       ValidatorEngine(Conf), InterpreterEngine(Conf, &Stat), StoreRef(S) {
   initVM();
 }
 
 void VM::initVM() {
   /// Create import modules from configuration.
-  if (Config.hasHostRegistration(HostRegistration::Wasi)) {
+  if (Conf.hasHostRegistration(HostRegistration::Wasi)) {
     std::unique_ptr<Runtime::ImportObject> WasiMod =
         std::make_unique<Host::WasiModule>();
     InterpreterEngine.registerModule(StoreRef, *WasiMod.get());
     ImpObjs.insert({HostRegistration::Wasi, std::move(WasiMod)});
   }
-  if (Config.hasHostRegistration(HostRegistration::SSVM_Process)) {
+  if (Conf.hasHostRegistration(HostRegistration::SSVM_Process)) {
     std::unique_ptr<Runtime::ImportObject> ProcMod =
         std::make_unique<Host::SSVMProcessModule>();
     InterpreterEngine.registerModule(StoreRef, *ProcMod.get());


### PR DESCRIPTION
1. Add the SSVM::AST::Module input of load wasm functions in VM and Loader.
2. Add Debug and Error logging level setting functions.
3. Add the function overloading and quantifiers in memory and table instances.
4. Copy the configuration class for the independent module in VM partitions.
5. Always register as an anonymous module when instantiation.