### PR TITLE
Value type checking when calling wasm functions

### DIFF
--- a/doc/externref.md
+++ b/doc/externref.md
@@ -105,7 +105,8 @@ Noted that `MulFunc` is a function definition in above, which is: `uint32_t MulF
 
 ```cpp
 std::vector<SSVM::ValVariant> FuncArgs = {SSVM::genExternRef(MulFunc), 789U, 4321U};
-std::vector<SSVM::ValVariant> Returns = *(VM.execute("call_mul", FuncArgs));
+std::vector<SSVM::ValType> FuncArgTypes = {SSVM::ValType::ExternRef, SSVM::ValType::I32, SSVM::ValType::I32};
+std::vector<SSVM::ValVariant> Returns = *(VM.execute("call_mul", FuncArgs, FuncArgTypes));
 std::cout << std::get<uint32_t>(Returns[0]); // will print 3409269
 ```
 
@@ -130,7 +131,8 @@ Then users can pass the object into SSVM by using `SSVM::genExternRef()` API.
 
 ```cpp
 std::vector<SSVM::ValVariant> FuncArgs = {SSVM::genExternRef(&AC), 1234U, 5678U};
-std::vector<SSVM::ValVariant> Returns = *(VM.execute("call_add", FuncArgs));
+std::vector<SSVM::ValType> FuncArgTypes = {SSVM::ValType::ExternRef, SSVM::ValType::I32, SSVM::ValType::I32};
+std::vector<SSVM::ValVariant> Returns = *(VM.execute("call_add", FuncArgs, FuncArgTypes));
 std::cout << std::get<uint32_t>(Returns[0]); // will print 6912
 ```
 
@@ -165,7 +167,8 @@ Then users can pass the object into SSVM by using `SSVM::genExternRef()` API.
 
 ```cpp
 std::vector<SSVM::ValVariant> FuncArgs = {SSVM::genExternRef(&SS), 1024U};
-std::vector<SSVM::ValVariant> Returns = *(VM.execute("call_square", FuncArgs));
+std::vector<SSVM::ValType> FuncArgTypes = {SSVM::ValType::ExternRef, SSVM::ValType::I32};
+std::vector<SSVM::ValVariant> Returns = *(VM.execute("call_square", FuncArgs, FuncArgTypes));
 std::cout << std::get<uint32_t>(Returns[0]); // will print 1048576
 ```
 
@@ -222,7 +225,8 @@ Last, pass the `std::cout` and a `std::string` object by external references.
 ```cpp
 std::string PrintStr("Hello world!");
 std::vector<SSVM::ValVariant> FuncArgs = {SSVM::genExternRef(&std::cout), SSVM::genExternRef(&PrintStr)};
-VM.execute("call_ostream_str", FuncArgs);
+std::vector<SSVM::ValType> FuncArgTypes = {SSVM::ValType::ExternRef, SSVM::ValType::ExternRef};
+VM.execute("call_ostream_str", FuncArgs, FuncArgTypes);
 /// Will get "Hello world!" in stdout.
 ```
 
@@ -323,9 +327,10 @@ int main() {
 
   /// Arguments are: reference to std::cout, reference to multiply function, and 123 and 456 to multiply
   std::vector<SSVM::ValVariant> FuncArgs = {SSVM::genExternRef(&std::cout), SSVM::genExternRef(MulFunc), 123U, 456U};
+  std::vector<SSVM::ValType> FuncArgTypes = {SSVM::ValType::ExternRef, SSVM::ValType::ExternRef, SSVM::ValType::I32, SSVM::ValType::I32};
 
   /// Call Wasm function
-  if (VM.execute("print_mul", FuncArgs)) {
+  if (VM.execute("print_mul", FuncArgs, FuncArgTypes)) {
     /// Success case, we will get "56088" in stdout.
     return EXIT_SUCCESS;
   } else {

--- a/include/ast/base.h
+++ b/include/ast/base.h
@@ -24,8 +24,8 @@ namespace AST {
 /// Base class of AST node.
 class Base {
 public:
-  Base() = default;
-  virtual ~Base() = default;
+  Base() noexcept = default;
+  virtual ~Base() noexcept = default;
 
   /// Binary loading from file manager.
   virtual Expect<void> loadBinary(FileMgr &Mgr, const Configure &Conf) = 0;

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -34,7 +34,7 @@ using InstrView = Span<const Instruction>;
 class Instruction {
 public:
   /// Constructor assigns the OpCode.
-  Instruction(const OpCode Byte, const uint32_t Off = 0)
+  Instruction(const OpCode Byte, const uint32_t Off = 0) noexcept
       : Code(Byte), Offset(Off) {}
   /// Copy constructor.
   Instruction(const Instruction &Instr) = default;

--- a/include/ast/type.h
+++ b/include/ast/type.h
@@ -27,9 +27,10 @@ public:
   /// Limit type enumeration class.
   enum class LimitType : uint8_t { HasMin = 0x00, HasMinMax = 0x01 };
 
-  Limit() = default;
-  Limit(const uint32_t MinVal) : Type(LimitType::HasMin), Min(MinVal) {}
-  Limit(const uint32_t MinVal, const uint32_t MaxVal)
+  Limit() noexcept = default;
+  Limit(const uint32_t MinVal) noexcept
+      : Type(LimitType::HasMin), Min(MinVal) {}
+  Limit(const uint32_t MinVal, const uint32_t MaxVal) noexcept
       : Type(LimitType::HasMinMax), Min(MinVal), Max(MaxVal) {}
 
   /// Load binary from file manager.

--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -42,7 +42,7 @@ extern const std::unordered_map<Proposal, std::string_view> ProposalStr;
 
 class Configure {
 public:
-  Configure() = default;
+  Configure() noexcept = default;
   template <typename... ArgsT> Configure(ArgsT... Args) noexcept {
     (addSet(Args), ...);
   }

--- a/include/common/statistics.h
+++ b/include/common/statistics.h
@@ -92,34 +92,40 @@ public:
   }
 
   /// Clear measurement data for instructions.
-  void clear() {
+  void clear() noexcept {
     TimeRecorder.reset();
     InstrCnt = 0;
     CostSum = 0;
   }
 
   /// Start recording wasm time.
-  void startRecordWasm() { TimeRecorder.startRecord(Timer::TimerTag::Wasm); }
+  void startRecordWasm() noexcept {
+    TimeRecorder.startRecord(Timer::TimerTag::Wasm);
+  }
 
   /// Stop recording wasm time.
-  void stopRecordWasm() { TimeRecorder.stopRecord(Timer::TimerTag::Wasm); }
+  void stopRecordWasm() noexcept {
+    TimeRecorder.stopRecord(Timer::TimerTag::Wasm);
+  }
 
   /// Start recording host function time.
-  void startRecordHost() {
+  void startRecordHost() noexcept {
     TimeRecorder.startRecord(Timer::TimerTag::HostFunc);
   }
 
   /// Stop recording host function time.
-  void stopRecordHost() { TimeRecorder.stopRecord(Timer::TimerTag::HostFunc); }
+  void stopRecordHost() noexcept {
+    TimeRecorder.stopRecord(Timer::TimerTag::HostFunc);
+  }
 
   /// Getter of execution time.
-  Timer::Timer::Clock::duration getWasmExecTime() const {
+  Timer::Timer::Clock::duration getWasmExecTime() const noexcept {
     return TimeRecorder.getRecord(Timer::TimerTag::Wasm);
   }
-  Timer::Timer::Clock::duration getHostFuncExecTime() const {
+  Timer::Timer::Clock::duration getHostFuncExecTime() const noexcept {
     return TimeRecorder.getRecord(Timer::TimerTag::HostFunc);
   }
-  Timer::Timer::Clock::duration getTotalExecTime() const {
+  Timer::Timer::Clock::duration getTotalExecTime() const noexcept {
     return TimeRecorder.getRecord(Timer::TimerTag::Wasm) +
            TimeRecorder.getRecord(Timer::TimerTag::HostFunc);
   }

--- a/include/common/value.h
+++ b/include/common/value.h
@@ -28,13 +28,13 @@ using ValVariant =
 using Byte = uint8_t;
 
 /// Reference types helper functions.
-inline constexpr RefVariant genNullRef(const RefType Type) {
+inline constexpr RefVariant genNullRef(const RefType Type) noexcept {
   return UINT64_C(0);
 }
-inline constexpr RefVariant genFuncRef(const uint32_t Idx) {
+inline constexpr RefVariant genFuncRef(const uint32_t Idx) noexcept {
   return FuncRef{1, Idx};
 }
-template <typename T> inline RefVariant genExternRef(T *Ref) {
+template <typename T> inline RefVariant genExternRef(T *Ref) noexcept {
   return ExternRef{reinterpret_cast<uint64_t *>(Ref)};
 }
 

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -111,7 +111,8 @@ public:
   /// Invoke function by function address in Store manager.
   Expect<std::vector<ValVariant>> invoke(Runtime::StoreManager &StoreMgr,
                                          const uint32_t FuncAddr,
-                                         Span<const ValVariant> Params);
+                                         Span<const ValVariant> Params,
+                                         Span<const ValType> ParamTypes);
 
 private:
   /// Run Wasm bytecode expression for initialization.

--- a/include/interpreter/interpreter.h
+++ b/include/interpreter/interpreter.h
@@ -83,7 +83,8 @@ using TypeNN =
 /// Executor flow control class.
 class Interpreter {
 public:
-  Interpreter(const Configure &Conf, Statistics::Statistics *S = nullptr)
+  Interpreter(const Configure &Conf,
+              Statistics::Statistics *S = nullptr) noexcept
       : Conf(Conf), Stat(S) {
     assert(This == nullptr);
     This = this;

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -26,8 +26,8 @@ namespace Loader {
 /// Loader flow control class.
 class Loader {
 public:
-  Loader(const Configure &Conf) : Conf(Conf) {}
-  ~Loader() = default;
+  Loader(const Configure &Conf) noexcept : Conf(Conf) {}
+  ~Loader() noexcept = default;
 
   /// Load data from file path.
   Expect<std::vector<Byte>> loadFile(const std::filesystem::path &FilePath);

--- a/include/runtime/instance/global.h
+++ b/include/runtime/instance/global.h
@@ -22,7 +22,7 @@ class GlobalInstance {
 public:
   GlobalInstance() = delete;
   GlobalInstance(const ValType ValueType, const ValMut Mutibility,
-                 const ValVariant Val = uint32_t(0))
+                 const ValVariant Val = uint32_t(0)) noexcept
       : Type(ValueType), Mut(Mutibility), Value(Val) {}
   virtual ~GlobalInstance() = default;
 

--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -72,7 +72,7 @@ public:
         PageLimit(Inst.PageLimit) {
     Inst.DataPtr = nullptr;
   }
-  MemoryInstance(const AST::Limit &Lim, const uint32_t PageLim = 65536)
+  MemoryInstance(const AST::Limit &Lim, const uint32_t PageLim = 65536) noexcept
       : HasMaxPage(Lim.hasMax()), MinPage(Lim.getMin()), MaxPage(Lim.getMax()),
         PageLimit(PageLim) {
     const auto UsableAddress = getUsableAddress();

--- a/include/runtime/storemgr.h
+++ b/include/runtime/storemgr.h
@@ -193,6 +193,15 @@ public:
     return {};
   }
 
+  /// Get list of registered modules.
+  const std::map<std::string, uint32_t, std::less<>> getModuleList() const {
+    std::map<std::string, uint32_t, std::less<>> ModMap;
+    for (uint32_t I = 0; I < ModInsts.size() - NumMod; I++) {
+      ModMap.emplace(ModInsts[I]->getModuleName(), I);
+    }
+    return ModMap;
+  }
+
   /// Get active instance of instantiated module.
   Expect<Instance::ModuleInstance *> getActiveModule() const {
     if (NumMod > 0) {
@@ -204,9 +213,9 @@ public:
 
   /// Find module by name.
   Expect<Instance::ModuleInstance *> findModule(std::string_view Name) {
-    for (auto It : ModInsts) {
-      if (It->getModuleName() == Name) {
-        return It;
+    for (uint32_t I = 0; I < ModInsts.size() - NumMod; I++) {
+      if (ModInsts[I]->getModuleName() == Name) {
+        return ModInsts[I];
       }
     }
     /// Error logging need to be handled in caller.

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -26,7 +26,7 @@ namespace Validator {
 class Validator {
 public:
   Validator(const Configure &Conf) noexcept : Conf(Conf) {}
-  ~Validator() = default;
+  ~Validator() noexcept = default;
 
   /// Validate AST::Module.
   Expect<void> validate(const AST::Module &Mod);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -51,13 +51,16 @@ public:
   /// Rapidly load, validate, instantiate, and run wasm function.
   Expect<std::vector<ValVariant>>
   runWasmFile(const std::filesystem::path &Path, std::string_view Func,
-              Span<const ValVariant> Params = {});
+              Span<const ValVariant> Params = {},
+              Span<const ValType> ParamTypes = {});
   Expect<std::vector<ValVariant>>
   runWasmFile(Span<const Byte> Code, std::string_view Func,
-              Span<const ValVariant> Params = {});
+              Span<const ValVariant> Params = {},
+              Span<const ValType> ParamTypes = {});
   Expect<std::vector<ValVariant>>
   runWasmFile(const AST::Module &Module, std::string_view Func,
-              Span<const ValVariant> Params = {});
+              Span<const ValVariant> Params = {},
+              Span<const ValType> ParamTypes = {});
 
   /// Load given wasm file, wasm bytecode, or wasm module.
   Expect<void> loadWasm(const std::filesystem::path &Path);
@@ -75,12 +78,14 @@ public:
   /// ======= Functions can be called after instantiated stage. =======
   /// Execute wasm with given input.
   Expect<std::vector<ValVariant>> execute(std::string_view Func,
-                                          Span<const ValVariant> Params = {});
+                                          Span<const ValVariant> Params = {},
+                                          Span<const ValType> ParamTypes = {});
 
   /// Execute function of registered module with given input.
   Expect<std::vector<ValVariant>> execute(std::string_view Mod,
                                           std::string_view Func,
-                                          Span<const ValVariant> Params = {});
+                                          Span<const ValVariant> Params = {},
+                                          Span<const ValType> ParamTypes = {});
 
   /// ======= Functions which are stageless. =======
   /// Clean up VM status

--- a/lib/interpreter/engine/control.cpp
+++ b/lib/interpreter/engine/control.cpp
@@ -134,16 +134,15 @@ Expect<void> Interpreter::runCallIndirectOp(Runtime::StoreManager &StoreMgr,
   }
 
   /// Get function address.
-  uint32_t FuncAddr;
   ValVariant Ref = *TabInst->getRefAddr(Idx);
   if (isNullRef(Ref)) {
+    LOG(ERROR) << ErrCode::UninitializedElement;
     LOG(ERROR) << ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset(),
                                            {Idx},
                                            {ValTypeFromType<uint32_t>()});
-    LOG(ERROR) << ErrCode::UninitializedElement;
     return Unexpect(ErrCode::UninitializedElement);
   }
-  FuncAddr = retrieveFuncIdx(Ref);
+  uint32_t FuncAddr = retrieveFuncIdx(Ref);
 
   /// Check function type.
   const auto *FuncInst = *StoreMgr.getFunction(FuncAddr);

--- a/lib/interpreter/instantiate/import.cpp
+++ b/lib/interpreter/instantiate/import.cpp
@@ -14,6 +14,24 @@ namespace SSVM {
 namespace Interpreter {
 
 namespace {
+template <typename... Args>
+auto logMatchError(std::string_view ModName, std::string_view ExtName,
+                   ExternalType ExtType, ASTNodeAttr Node, Args &&... Values) {
+  LOG(ERROR) << ErrCode::IncompatibleImportType;
+  LOG(ERROR) << ErrInfo::InfoMismatch(std::forward<Args>(Values)...);
+  LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
+  LOG(ERROR) << ErrInfo::InfoAST(Node);
+  return Unexpect(ErrCode::IncompatibleImportType);
+}
+
+auto logUnknownError(std::string_view ModName, std::string_view ExtName,
+                     ExternalType ExtType, ASTNodeAttr Node) {
+  LOG(ERROR) << ErrCode::UnknownImport;
+  LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
+  LOG(ERROR) << ErrInfo::InfoAST(Node);
+  return Unexpect(ErrCode::UnknownImport);
+}
+
 bool isLimitMatched(const bool HasMax1, const uint32_t Min1,
                     const uint32_t Max1, const bool HasMax2,
                     const uint32_t Min2, const uint32_t Max2) {
@@ -26,8 +44,9 @@ bool isLimitMatched(const bool HasMax1, const uint32_t Min1,
   return true;
 }
 
-Expect<uint32_t> getImportAddr(std::string_view Name,
-                               const ExternalType ExtType,
+Expect<uint32_t> getImportAddr(std::string_view ModName,
+                               std::string_view ExtName,
+                               const ExternalType ExtType, ASTNodeAttr Node,
                                Runtime::Instance::ModuleInstance &ModInst) {
   const auto &FuncList = ModInst.getFuncExports();
   const auto &TabList = ModInst.getTableExports();
@@ -36,54 +55,48 @@ Expect<uint32_t> getImportAddr(std::string_view Name,
 
   switch (ExtType) {
   case ExternalType::Function:
-    if (FuncList.find(Name) != FuncList.cend()) {
-      return FuncList.find(Name)->second;
+    if (FuncList.find(ExtName) != FuncList.cend()) {
+      return FuncList.find(ExtName)->second;
     }
     break;
   case ExternalType::Table:
-    if (TabList.find(Name) != TabList.cend()) {
-      return TabList.find(Name)->second;
+    if (TabList.find(ExtName) != TabList.cend()) {
+      return TabList.find(ExtName)->second;
     }
     break;
   case ExternalType::Memory:
-    if (MemList.find(Name) != MemList.cend()) {
-      return MemList.find(Name)->second;
+    if (MemList.find(ExtName) != MemList.cend()) {
+      return MemList.find(ExtName)->second;
     }
     break;
   case ExternalType::Global:
-    if (GlobList.find(Name) != GlobList.cend()) {
-      return GlobList.find(Name)->second;
+    if (GlobList.find(ExtName) != GlobList.cend()) {
+      return GlobList.find(ExtName)->second;
     }
     break;
   default:
-    LOG(ERROR) << ErrCode::UnknownImport;
-    return Unexpect(ErrCode::UnknownImport);
+    return logUnknownError(ModName, ExtName, ExtType, Node);
   }
 
   /// Check is error external type or unknown imports.
-  if (FuncList.find(Name) != FuncList.cend()) {
-    LOG(ERROR) << ErrCode::IncompatibleImportType;
-    LOG(ERROR) << ErrInfo::InfoMismatch(ExtType, ExternalType::Function);
-    return Unexpect(ErrCode::IncompatibleImportType);
+  if (FuncList.find(ExtName) != FuncList.cend()) {
+    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+                         ExternalType::Function);
   }
-  if (TabList.find(Name) != TabList.cend()) {
-    LOG(ERROR) << ErrCode::IncompatibleImportType;
-    LOG(ERROR) << ErrInfo::InfoMismatch(ExtType, ExternalType::Table);
-    return Unexpect(ErrCode::IncompatibleImportType);
+  if (TabList.find(ExtName) != TabList.cend()) {
+    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+                         ExternalType::Table);
   }
-  if (MemList.find(Name) != MemList.cend()) {
-    LOG(ERROR) << ErrCode::IncompatibleImportType;
-    LOG(ERROR) << ErrInfo::InfoMismatch(ExtType, ExternalType::Memory);
-    return Unexpect(ErrCode::IncompatibleImportType);
+  if (MemList.find(ExtName) != MemList.cend()) {
+    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+                         ExternalType::Memory);
   }
-  if (GlobList.find(Name) != GlobList.cend()) {
-    LOG(ERROR) << ErrCode::IncompatibleImportType;
-    LOG(ERROR) << ErrInfo::InfoMismatch(ExtType, ExternalType::Global);
-    return Unexpect(ErrCode::IncompatibleImportType);
+  if (GlobList.find(ExtName) != GlobList.cend()) {
+    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+                         ExternalType::Global);
   }
 
-  LOG(ERROR) << ErrCode::UnknownImport;
-  return Unexpect(ErrCode::UnknownImport);
+  return logUnknownError(ModName, ExtName, ExtType, Node);
 }
 } // namespace
 
@@ -103,12 +116,10 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
     if (auto Res = StoreMgr.findModule(ModName)) {
       TargetModInst = *Res;
     } else {
-      LOG(ERROR) << ErrCode::UnknownImport;
-      LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
-      LOG(ERROR) << ErrInfo::InfoAST(ImpDesc.NodeAttr);
-      return Unexpect(ErrCode::UnknownImport);
+      return logUnknownError(ModName, ExtName, ExtType, ImpDesc.NodeAttr);
     }
-    if (auto Res = getImportAddr(ExtName, ExtType, *TargetModInst)) {
+    if (auto Res = getImportAddr(ModName, ExtName, ExtType, ImpDesc.NodeAttr,
+                                 *TargetModInst)) {
       TargetAddr = *Res;
     } else {
       LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
@@ -127,13 +138,9 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       const auto *FuncType = *ModInst.getFuncType(TypeIdx);
       if (TargetType.Params != FuncType->Params ||
           TargetType.Returns != FuncType->Returns) {
-        LOG(ERROR) << ErrCode::IncompatibleImportType;
-        LOG(ERROR) << ErrInfo::InfoMismatch(FuncType->Params, FuncType->Returns,
-                                            TargetType.Params,
-                                            TargetType.Returns);
-        LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
-        LOG(ERROR) << ErrInfo::InfoAST(ImpDesc.NodeAttr);
-        return Unexpect(ErrCode::IncompatibleImportType);
+        return logMatchError(ModName, ExtName, ExtType, ImpDesc.NodeAttr,
+                             FuncType->Params, FuncType->Returns,
+                             TargetType.Params, TargetType.Returns);
       }
       /// Set the matched function address to module instance.
       ModInst.importFunction(TargetAddr);
@@ -149,15 +156,12 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
           !isLimitMatched(TargetInst->getHasMax(), TargetInst->getMin(),
                           TargetInst->getMax(), TabLim.hasMax(),
                           TabLim.getMin(), TabLim.getMax())) {
-        LOG(ERROR) << ErrCode::IncompatibleImportType;
-        LOG(ERROR) << ErrInfo::InfoMismatch(
-            TabType.getReferenceType(), TabLim.hasMax(), TabLim.getMin(),
-            TabLim.getMax(), TargetInst->getReferenceType(),
-            TargetInst->getHasMax(), TargetInst->getMin(),
-            TargetInst->getMax());
-        LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
-        LOG(ERROR) << ErrInfo::InfoAST(ImpDesc.NodeAttr);
-        return Unexpect(ErrCode::IncompatibleImportType);
+        return logMatchError(ModName, ExtName, ExtType, ImpDesc.NodeAttr,
+                             TabType.getReferenceType(), TabLim.hasMax(),
+                             TabLim.getMin(), TabLim.getMax(),
+                             TargetInst->getReferenceType(),
+                             TargetInst->getHasMax(), TargetInst->getMin(),
+                             TargetInst->getMax());
       }
       /// Set the matched table address to module instance.
       ModInst.importTable(TargetAddr);
@@ -172,14 +176,10 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       if (!isLimitMatched(TargetInst->getHasMax(), TargetInst->getMin(),
                           TargetInst->getMax(), MemLim.hasMax(),
                           MemLim.getMin(), MemLim.getMax())) {
-        LOG(ERROR) << ErrCode::IncompatibleImportType;
-        LOG(ERROR) << ErrInfo::InfoMismatch(
-            MemLim.hasMax(), MemLim.getMin(), MemLim.getMax(),
-            TargetInst->getHasMax(), TargetInst->getMin(),
-            TargetInst->getMax());
-        LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
-        LOG(ERROR) << ErrInfo::InfoAST(ImpDesc.NodeAttr);
-        return Unexpect(ErrCode::IncompatibleImportType);
+        return logMatchError(ModName, ExtName, ExtType, ImpDesc.NodeAttr,
+                             MemLim.hasMax(), MemLim.getMin(), MemLim.getMax(),
+                             TargetInst->getHasMax(), TargetInst->getMin(),
+                             TargetInst->getMax());
       }
       /// Set the matched memory address to module instance.
       ModInst.importMemory(TargetAddr);
@@ -192,13 +192,10 @@ Interpreter::instantiate(Runtime::StoreManager &StoreMgr,
       auto *TargetInst = *StoreMgr.getGlobal(TargetAddr);
       if (TargetInst->getValType() != GlobType.getValueType() ||
           TargetInst->getValMut() != GlobType.getValueMutation()) {
-        LOG(ERROR) << ErrCode::IncompatibleImportType;
-        LOG(ERROR) << ErrInfo::InfoMismatch(
-            GlobType.getValueType(), GlobType.getValueMutation(),
-            TargetInst->getValType(), TargetInst->getValMut());
-        LOG(ERROR) << ErrInfo::InfoLinking(ModName, ExtName, ExtType);
-        LOG(ERROR) << ErrInfo::InfoAST(ImpDesc.NodeAttr);
-        return Unexpect(ErrCode::IncompatibleImportType);
+        return logMatchError(ModName, ExtName, ExtType, ImpDesc.NodeAttr,
+                             GlobType.getValueType(),
+                             GlobType.getValueMutation(),
+                             TargetInst->getValType(), TargetInst->getValMut());
       }
       /// Set the matched global address to module instance.
       ModInst.importGlobal(TargetAddr);

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -20,6 +20,7 @@
 #include "validator/validator.h"
 #include "vm/vm.h"
 
+#include "../spec/hostfunc.h"
 #include "../spec/spectest.h"
 #include "gtest/gtest.h"
 

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -100,11 +100,11 @@ TEST_P(CoreTest, TestSuites) {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
       /// Store Manager.
-      return VM.execute(ModName, Field, Params);
+      return VM.execute(ModName, Field, Params, ParamTypes);
     } else {
       /// Invoke function of anonymous module. Anonymous modules are
       /// instantiated in VM.
-      return VM.execute(Field, Params);
+      return VM.execute(Field, Params, ParamTypes);
     }
   };
   /// Helper function to get values.

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -24,12 +24,9 @@
 #include "../spec/spectest.h"
 #include "gtest/gtest.h"
 
-#include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -97,7 +94,8 @@ TEST_P(CoreTest, TestSuites) {
   };
   /// Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
-                     const std::vector<ValVariant> &Params)
+                     const std::vector<ValVariant> &Params,
+                     const std::vector<ValType> &ParamTypes)
       -> Expect<std::vector<ValVariant>> {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
@@ -134,176 +132,6 @@ TEST_P(CoreTest, TestSuites) {
     auto *GlobInst = *Store.getGlobal(GlobAddr);
 
     return std::vector<SSVM::ValVariant>{GlobInst->getValue()};
-  };
-  T.onCompare =
-      [](const std::vector<std::pair<std::string, std::string>> &Expected,
-         const std::vector<ValVariant> &Got) -> bool {
-    if (Expected.size() != Got.size()) {
-      return false;
-    }
-    for (size_t I = 0; I < Expected.size(); ++I) {
-      const auto &[Type, E] = Expected[I];
-      const auto &G = Got[I];
-      /// Handle NaN case
-      if (E.substr(0, 4) == "nan:"sv) {
-        /// TODO: nan:canonical and nan:arithmetic
-        if (Type == "f32"sv) {
-          const float F = std::get<float>(G);
-          if (!std::isnan(F)) {
-            return false;
-          }
-        } else if (Type == "f64"sv) {
-          const double D = std::get<double>(G);
-          if (!std::isnan(D)) {
-            return false;
-          }
-        }
-      } else if (Type == "i32"sv || Type == "f32"sv) {
-        const uint32_t V1 = uint32_t(std::stoul(E));
-        const uint32_t V2 = std::get<uint32_t>(G);
-        if (V1 != V2) {
-          return false;
-        }
-      } else if (Type == "i64"sv || Type == "f64"sv) {
-        const uint64_t V2 = uint64_t(std::stoull(E));
-        const uint64_t V1 = std::get<uint64_t>(G);
-        if (V1 != V2) {
-          return false;
-        }
-      } else if (std::string_view(Type).substr(0, 4) == "v128"sv) {
-        std::vector<std::string_view> Parts;
-        std::string_view Ev = E;
-        for (std::string::size_type Begin = 0, End = Ev.find(' ');
-             Begin != std::string::npos;
-             Begin = 1 + End, End = Ev.find(' ', Begin)) {
-          Parts.push_back(Ev.substr(Begin, End - Begin));
-          if (End == std::string::npos) {
-            break;
-          }
-        }
-        std::string_view LaneType = std::string_view(Type).substr(4);
-        if (LaneType == "f32") {
-          using floatx4_t [[gnu::vector_size(16)]] = float;
-          using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
-          const auto VF = reinterpret_cast<floatx4_t>(std::get<uint128_t>(G));
-          const auto VI = reinterpret_cast<uint32x4_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 4; ++I) {
-            if (Parts[I].substr(0, 4) == "nan:"sv) {
-              if (!std::isnan(VF[I])) {
-                return false;
-              }
-            } else {
-              const uint32_t V2 = std::stoull(std::string(Parts[I]));
-              const uint32_t V1 = VI[I];
-              if (V1 != V2) {
-                return false;
-              }
-            }
-          }
-        } else if (LaneType == "f64") {
-          using doublex2_t [[gnu::vector_size(16)]] = double;
-          using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-          const auto VF = reinterpret_cast<doublex2_t>(std::get<uint128_t>(G));
-          const auto VI = reinterpret_cast<uint64x2_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 2; ++I) {
-            if (Parts[I].substr(0, 4) == "nan:"sv) {
-              if (!std::isnan(VF[I])) {
-                return false;
-              }
-            } else {
-              const uint64_t V2 = std::stoull(std::string(Parts[I]));
-              const uint64_t V1 = VI[I];
-              if (V1 != V2) {
-                return false;
-              }
-            }
-          }
-        } else if (LaneType == "i8") {
-          using uint8x16_t [[gnu::vector_size(16)]] = uint8_t;
-          const auto V = reinterpret_cast<uint8x16_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 16; ++I) {
-            const uint8_t V2 = std::stoul(std::string(Parts[I]));
-            const uint8_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        } else if (LaneType == "i16") {
-          using uint16x8_t [[gnu::vector_size(16)]] = uint16_t;
-          const auto V = reinterpret_cast<uint16x8_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 8; ++I) {
-            const uint16_t V2 = std::stoul(std::string(Parts[I]));
-            const uint16_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        } else if (LaneType == "i32") {
-          using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
-          const auto V = reinterpret_cast<uint32x4_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 4; ++I) {
-            const uint32_t V2 = std::stoul(std::string(Parts[I]));
-            const uint32_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        } else if (LaneType == "i64") {
-          using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-          const auto V = reinterpret_cast<uint64x2_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 2; ++I) {
-            const uint64_t V2 = std::stoul(std::string(Parts[I]));
-            const uint64_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        }
-      } else if (Type == "funcref"sv) {
-        /// Handle reference value case
-        if (E == "null"sv) {
-          return SSVM::isNullRef(G);
-        } else {
-          if (SSVM::isNullRef(G)) {
-            return false;
-          }
-          uint32_t V1 = SSVM::retrieveFuncIdx(G);
-          uint32_t V2 = static_cast<uint32_t>(std::stoul(E));
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else if (Type == "externref"sv) {
-        /// Handle reference value case
-        if (E == "null"sv) {
-          return SSVM::isNullRef(G);
-        } else {
-          if (SSVM::isNullRef(G)) {
-            return false;
-          }
-          /// The added 0x1 uint32_t prefix in externref index case will be
-          /// discarded
-          uint32_t V1 = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
-              &SSVM::retrieveExternRef<uint32_t>(G)));
-          uint32_t V2 = static_cast<uint32_t>(std::stoul(E));
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else {
-        assert(false);
-      }
-    }
-    return true;
-  };
-  T.onStringContains = [](const std::string &Expected,
-                          const std::string &Got) -> bool {
-    if (Expected.rfind(Got, 0) != 0) {
-      std::cout << "   ##### expected text : " << Expected << '\n';
-      std::cout << "   ######## error text : " << Got << '\n';
-      return false;
-    }
-    return true;
   };
 
   T.run(Proposal, UnitName);

--- a/test/interpreter/InterpreterTest.cpp
+++ b/test/interpreter/InterpreterTest.cpp
@@ -21,12 +21,9 @@
 #include "../spec/spectest.h"
 #include "gtest/gtest.h"
 
-#include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -63,7 +60,8 @@ TEST_P(CoreTest, TestSuites) {
   };
   /// Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
-                     const std::vector<ValVariant> &Params)
+                     const std::vector<ValVariant> &Params,
+                     const std::vector<ValType> &ParamTypes)
       -> Expect<std::vector<ValVariant>> {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
@@ -100,176 +98,6 @@ TEST_P(CoreTest, TestSuites) {
     auto *GlobInst = *Store.getGlobal(GlobAddr);
 
     return std::vector<SSVM::ValVariant>{GlobInst->getValue()};
-  };
-  T.onCompare =
-      [](const std::vector<std::pair<std::string, std::string>> &Expected,
-         const std::vector<ValVariant> &Got) -> bool {
-    if (Expected.size() != Got.size()) {
-      return false;
-    }
-    for (size_t I = 0; I < Expected.size(); ++I) {
-      const auto &[Type, E] = Expected[I];
-      const auto &G = Got[I];
-      if (E.substr(0, 4) == "nan:"sv) {
-        /// Handle NaN case
-        /// TODO: nan:canonical and nan:arithmetic
-        if (Type == "f32"sv) {
-          const float F = std::get<float>(G);
-          if (!std::isnan(F)) {
-            return false;
-          }
-        } else if (Type == "f64"sv) {
-          const double D = std::get<double>(G);
-          if (!std::isnan(D)) {
-            return false;
-          }
-        }
-      } else if (Type == "funcref"sv) {
-        /// Handle reference value case
-        if (E == "null"sv) {
-          return SSVM::isNullRef(G);
-        } else {
-          if (SSVM::isNullRef(G)) {
-            return false;
-          }
-          uint32_t V1 = SSVM::retrieveFuncIdx(G);
-          uint32_t V2 = static_cast<uint32_t>(std::stoul(E));
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else if (Type == "externref"sv) {
-        /// Handle reference value case
-        if (E == "null"sv) {
-          return SSVM::isNullRef(G);
-        } else {
-          if (SSVM::isNullRef(G)) {
-            return false;
-          }
-          /// The added 0x1 uint32_t prefix in externref index case will be
-          /// discarded
-          uint32_t V1 = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
-              &SSVM::retrieveExternRef<uint32_t>(G)));
-          uint32_t V2 = static_cast<uint32_t>(std::stoul(E));
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else if (Type == "i32"sv || Type == "f32"sv) {
-        const uint32_t V1 = uint32_t(std::stoul(E));
-        const uint32_t V2 = std::get<uint32_t>(G);
-        if (V1 != V2) {
-          return false;
-        }
-      } else if (Type == "i64"sv || Type == "f64"sv) {
-        const uint64_t V2 = uint64_t(std::stoull(E));
-        const uint64_t V1 = std::get<uint64_t>(G);
-        if (V1 != V2) {
-          return false;
-        }
-      } else if (std::string_view(Type).substr(0, 4) == "v128"sv) {
-        std::vector<std::string_view> Parts;
-        std::string_view Ev = E;
-        for (std::string::size_type Begin = 0, End = Ev.find(' ');
-             Begin != std::string::npos;
-             Begin = 1 + End, End = Ev.find(' ', Begin)) {
-          Parts.push_back(Ev.substr(Begin, End - Begin));
-          if (End == std::string::npos) {
-            break;
-          }
-        }
-        std::string_view LaneType = std::string_view(Type).substr(4);
-        if (LaneType == "f32") {
-          using floatx4_t [[gnu::vector_size(16)]] = float;
-          using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
-          const auto VF = reinterpret_cast<floatx4_t>(std::get<uint128_t>(G));
-          const auto VI = reinterpret_cast<uint32x4_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 4; ++I) {
-            if (Parts[I].substr(0, 4) == "nan:"sv) {
-              if (!std::isnan(VF[I])) {
-                return false;
-              }
-            } else {
-              const uint32_t V2 = std::stoull(std::string(Parts[I]));
-              const uint32_t V1 = VI[I];
-              if (V1 != V2) {
-                return false;
-              }
-            }
-          }
-        } else if (LaneType == "f64") {
-          using doublex2_t [[gnu::vector_size(16)]] = double;
-          using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-          const auto VF = reinterpret_cast<doublex2_t>(std::get<uint128_t>(G));
-          const auto VI = reinterpret_cast<uint64x2_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 2; ++I) {
-            if (Parts[I].substr(0, 4) == "nan:"sv) {
-              if (!std::isnan(VF[I])) {
-                return false;
-              }
-            } else {
-              const uint64_t V2 = std::stoull(std::string(Parts[I]));
-              const uint64_t V1 = VI[I];
-              if (V1 != V2) {
-                return false;
-              }
-            }
-          }
-        } else if (LaneType == "i8") {
-          using uint8x16_t [[gnu::vector_size(16)]] = uint8_t;
-          const auto V = reinterpret_cast<uint8x16_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 16; ++I) {
-            const uint8_t V2 = std::stoul(std::string(Parts[I]));
-            const uint8_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        } else if (LaneType == "i16") {
-          using uint16x8_t [[gnu::vector_size(16)]] = uint16_t;
-          const auto V = reinterpret_cast<uint16x8_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 8; ++I) {
-            const uint16_t V2 = std::stoul(std::string(Parts[I]));
-            const uint16_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        } else if (LaneType == "i32") {
-          using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
-          const auto V = reinterpret_cast<uint32x4_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 4; ++I) {
-            const uint32_t V2 = std::stoul(std::string(Parts[I]));
-            const uint32_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        } else if (LaneType == "i64") {
-          using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-          const auto V = reinterpret_cast<uint64x2_t>(std::get<uint128_t>(G));
-          for (size_t I = 0; I < 2; ++I) {
-            const uint64_t V2 = std::stoul(std::string(Parts[I]));
-            const uint64_t V1 = V[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        }
-      } else {
-        assert(false);
-      }
-    }
-    return true;
-  };
-  T.onStringContains = [](const std::string &Expected,
-                          const std::string &Got) -> bool {
-    if (Expected.rfind(Got, 0) != 0) {
-      std::cout << "   ##### expected text : " << Expected << '\n';
-      std::cout << "   ######## error text : " << Got << '\n';
-      return false;
-    }
-    return true;
   };
 
   T.run(Proposal, UnitName);

--- a/test/interpreter/InterpreterTest.cpp
+++ b/test/interpreter/InterpreterTest.cpp
@@ -17,6 +17,7 @@
 #include "common/log.h"
 #include "vm/vm.h"
 
+#include "../spec/hostfunc.h"
 #include "../spec/spectest.h"
 #include "gtest/gtest.h"
 

--- a/test/interpreter/InterpreterTest.cpp
+++ b/test/interpreter/InterpreterTest.cpp
@@ -66,11 +66,11 @@ TEST_P(CoreTest, TestSuites) {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
       /// Store Manager.
-      return VM.execute(ModName, Field, Params);
+      return VM.execute(ModName, Field, Params, ParamTypes);
     } else {
       /// Invoke function of anonymous module. Anonymous modules are
       /// instantiated in VM.
-      return VM.execute(Field, Params);
+      return VM.execute(Field, Params, ParamTypes);
     }
   };
   /// Helper function to get values.

--- a/test/spec/hostfunc.h
+++ b/test/spec/hostfunc.h
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+//===-- ssvm/test/spec/hostfunc.h - Spec test host functions --------------===//
+//
+// Part of the SSVM Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file parse and run tests of Wasm test suites extracted by wast2json.
+/// Test Suits: https://github.com/WebAssembly/spec/tree/master/test/core
+/// wast2json: https://webassembly.github.io/wabt/doc/wast2json.1.html
+///
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common/errcode.h"
+#include "runtime/hostfunc.h"
+#include "runtime/importobj.h"
+#include "runtime/instance/memory.h"
+
+namespace SSVM {
+
+class SpecTestPrint : public Runtime::HostFunction<SpecTestPrint> {
+public:
+  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst) { return {}; }
+};
+
+class SpecTestPrintI32 : public Runtime::HostFunction<SpecTestPrintI32> {
+public:
+  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, uint32_t Val) {
+    return {};
+  }
+};
+
+class SpecTestPrintF32 : public Runtime::HostFunction<SpecTestPrintF32> {
+public:
+  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, float Val) {
+    return {};
+  }
+};
+
+class SpecTestPrintF64 : public Runtime::HostFunction<SpecTestPrintF64> {
+public:
+  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, double Val) {
+    return {};
+  }
+};
+
+class SpecTestPrintI32F32 : public Runtime::HostFunction<SpecTestPrintI32F32> {
+public:
+  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, uint32_t Val1,
+                    float Val2) {
+    return {};
+  }
+};
+
+class SpecTestPrintF64F64 : public Runtime::HostFunction<SpecTestPrintF64F64> {
+public:
+  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, double IVal,
+                    double Val2) {
+    return {};
+  }
+};
+
+class SpecTestModule : public Runtime::ImportObject {
+public:
+  SpecTestModule() : ImportObject("spectest") {
+    addHostFunc("print", std::make_unique<SpecTestPrint>());
+    addHostFunc("print_i32", std::make_unique<SpecTestPrintI32>());
+    addHostFunc("print_f32", std::make_unique<SpecTestPrintF32>());
+    addHostFunc("print_f64", std::make_unique<SpecTestPrintF64>());
+    addHostFunc("print_i32_f32", std::make_unique<SpecTestPrintI32F32>());
+    addHostFunc("print_f64_f64", std::make_unique<SpecTestPrintF64F64>());
+
+    AST::Limit TabLimit(10, 20);
+    addHostTable("table", std::make_unique<Runtime::Instance::TableInstance>(
+                              RefType::FuncRef, TabLimit));
+
+    AST::Limit MemLimit(1, 2);
+    addHostMemory("memory", std::make_unique<Runtime::Instance::MemoryInstance>(
+                                MemLimit));
+
+    addHostGlobal("global_i32",
+                  std::make_unique<Runtime::Instance::GlobalInstance>(
+                      ValType::I32, ValMut::Const, uint32_t(666)));
+    addHostGlobal("global_i64",
+                  std::make_unique<Runtime::Instance::GlobalInstance>(
+                      ValType::I64, ValMut::Const, uint64_t(666)));
+    addHostGlobal("global_f32",
+                  std::make_unique<Runtime::Instance::GlobalInstance>(
+                      ValType::F32, ValMut::Const, float(666)));
+    addHostGlobal("global_f64",
+                  std::make_unique<Runtime::Instance::GlobalInstance>(
+                      ValType::F64, ValMut::Const, double(666)));
+  }
+  virtual ~SpecTestModule() = default;
+};
+
+} // namespace SSVM

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -21,7 +21,10 @@
 #define RAPIDJSON_NEON 1
 #endif
 
+#include "common/log.h"
+
 #include "spectest.h"
+
 #include "rapidjson/document.h"
 #include "rapidjson/istreamwrapper.h"
 #include "gtest/gtest.h"
@@ -316,7 +319,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
 
   /// Command processing. Return true for expected result.
   auto RunCommand = [&](const rapidjson::Value &Cmd) {
-    /// Line number in wast: It->GetObject()["line"].GetInt()
+    /// Line number in wast: Cmd["line"].Get<uint32_t>()
     if (const auto Type = Cmd.FindMember("type"s); Type != Cmd.MemberEnd()) {
       switch (resolveCommand(Type->value.Get<std::string>())) {
       case SpecTest::CommandID::Module: {

--- a/test/spec/spectest.h
+++ b/test/spec/spectest.h
@@ -46,6 +46,10 @@ public:
   std::vector<std::string> enumerate() const;
   std::tuple<std::string_view, SSVM::Configure, std::string>
   resolve(std::string_view Params) const;
+  bool compare(const std::vector<std::pair<std::string, std::string>> &Expected,
+               const std::vector<ValVariant> &Got) const;
+  bool stringContains(const std::string &Expected,
+                      const std::string &Got) const;
 
   void run(std::string_view Proposal, std::string_view UnitName);
 
@@ -61,22 +65,13 @@ public:
 
   using InvokeCallback = Expect<std::vector<ValVariant>>(
       const std::string &ModName, const std::string &Field,
-      const std::vector<ValVariant> &Params);
+      const std::vector<ValVariant> &Params,
+      const std::vector<ValType> &ParamTypes);
   std::function<InvokeCallback> onInvoke;
 
   using GetCallback = Expect<std::vector<ValVariant>>(
       const std::string &ModName, const std::string &Field);
   std::function<GetCallback> onGet;
-
-  /// Helper function to compare return values with expected values.
-  using CompareCallback =
-      bool(const std::vector<std::pair<std::string, std::string>> &Expected,
-           const std::vector<ValVariant> &Got);
-  std::function<CompareCallback> onCompare;
-
-  using StringContainsCallback = bool(const std::string &Expected,
-                                      const std::string &Got);
-  std::function<StringContainsCallback> onStringContains;
 
 private:
   std::filesystem::path TestsuiteRoot;

--- a/test/spec/spectest.h
+++ b/test/spec/spectest.h
@@ -17,91 +17,12 @@
 #include "common/configure.h"
 #include "common/errcode.h"
 #include "common/filesystem.h"
-#include "runtime/hostfunc.h"
-#include "runtime/importobj.h"
-#include "runtime/instance/memory.h"
 
 #include <functional>
 #include <string_view>
 #include <vector>
 
 namespace SSVM {
-
-class SpecTestPrint : public Runtime::HostFunction<SpecTestPrint> {
-public:
-  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst) { return {}; }
-};
-
-class SpecTestPrintI32 : public Runtime::HostFunction<SpecTestPrintI32> {
-public:
-  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, uint32_t Val) {
-    return {};
-  }
-};
-
-class SpecTestPrintF32 : public Runtime::HostFunction<SpecTestPrintF32> {
-public:
-  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, float Val) {
-    return {};
-  }
-};
-
-class SpecTestPrintF64 : public Runtime::HostFunction<SpecTestPrintF64> {
-public:
-  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, double Val) {
-    return {};
-  }
-};
-
-class SpecTestPrintI32F32 : public Runtime::HostFunction<SpecTestPrintI32F32> {
-public:
-  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, uint32_t Val1,
-                    float Val2) {
-    return {};
-  }
-};
-
-class SpecTestPrintF64F64 : public Runtime::HostFunction<SpecTestPrintF64F64> {
-public:
-  Expect<void> body(Runtime::Instance::MemoryInstance *MemInst, double IVal,
-                    double Val2) {
-    return {};
-  }
-};
-
-class SpecTestModule : public Runtime::ImportObject {
-public:
-  SpecTestModule() : ImportObject("spectest") {
-    addHostFunc("print", std::make_unique<SpecTestPrint>());
-    addHostFunc("print_i32", std::make_unique<SpecTestPrintI32>());
-    addHostFunc("print_f32", std::make_unique<SpecTestPrintF32>());
-    addHostFunc("print_f64", std::make_unique<SpecTestPrintF64>());
-    addHostFunc("print_i32_f32", std::make_unique<SpecTestPrintI32F32>());
-    addHostFunc("print_f64_f64", std::make_unique<SpecTestPrintF64F64>());
-
-    AST::Limit TabLimit(10, 20);
-    addHostTable("table", std::make_unique<Runtime::Instance::TableInstance>(
-                              RefType::FuncRef, TabLimit));
-
-    AST::Limit MemLimit(1, 2);
-    addHostMemory("memory", std::make_unique<Runtime::Instance::MemoryInstance>(
-                                MemLimit));
-
-    addHostGlobal("global_i32",
-                  std::make_unique<Runtime::Instance::GlobalInstance>(
-                      ValType::I32, ValMut::Const, uint32_t(666)));
-    addHostGlobal("global_i64",
-                  std::make_unique<Runtime::Instance::GlobalInstance>(
-                      ValType::I64, ValMut::Const, uint64_t(666)));
-    addHostGlobal("global_f32",
-                  std::make_unique<Runtime::Instance::GlobalInstance>(
-                      ValType::F32, ValMut::Const, float(666)));
-    addHostGlobal("global_f64",
-                  std::make_unique<Runtime::Instance::GlobalInstance>(
-                      ValType::F64, ValMut::Const, double(666)));
-  }
-  virtual ~SpecTestModule() = default;
-};
 
 class SpecTest {
 public:

--- a/tools/ssvm/ssvmr.cpp
+++ b/tools/ssvm/ssvmr.cpp
@@ -166,27 +166,32 @@ int main(int Argc, const char *Argv[]) {
     }
 
     std::vector<SSVM::ValVariant> FuncArgs;
+    std::vector<SSVM::ValType> FuncArgTypes;
     for (size_t I = 0;
          I < FuncType.Params.size() && I + 1 < Args.value().size(); ++I) {
       switch (FuncType.Params[I]) {
       case SSVM::ValType::I32: {
         const uint32_t Value = std::stoll(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
+        FuncArgTypes.emplace_back(SSVM::ValType::I32);
         break;
       }
       case SSVM::ValType::I64: {
         const uint64_t Value = std::stoll(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
+        FuncArgTypes.emplace_back(SSVM::ValType::I64);
         break;
       }
       case SSVM::ValType::F32: {
         const float Value = std::stod(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
+        FuncArgTypes.emplace_back(SSVM::ValType::F32);
         break;
       }
       case SSVM::ValType::F64: {
         const double Value = std::stod(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
+        FuncArgTypes.emplace_back(SSVM::ValType::F64);
         break;
       }
       /// TODO: FuncRef and ExternRef
@@ -199,10 +204,11 @@ int main(int Argc, const char *Argv[]) {
            ++I) {
         const uint64_t Value = std::stoll(Args.value()[I]);
         FuncArgs.emplace_back(Value);
+        FuncArgTypes.emplace_back(SSVM::ValType::F64);
       }
     }
 
-    if (auto Result = VM.execute(FuncName, FuncArgs)) {
+    if (auto Result = VM.execute(FuncName, FuncArgs, FuncArgTypes)) {
       /// Print results.
       for (size_t I = 0; I < FuncType.Returns.size(); ++I) {
         switch (FuncType.Returns[I]) {


### PR DESCRIPTION
1. Refactor SpecTest class for combining duplicated codes.
2. Apply function parameter type checking when calling wasm functions.
3. Update tools, doc, and tests.